### PR TITLE
Disallow quoted block named in `block-name`  rule.

### DIFF
--- a/src/BlockParser.ts
+++ b/src/BlockParser.ts
@@ -13,7 +13,8 @@ const SIBLING_COMBINATORS = new Set(["+", "~"]);
 const HIERARCHICAL_COMBINATORS = new Set([" ", ">"]);
 const LEGAL_COMBINATORS = new Set(["+", "~", " ", ">"]);
 
-export const CLASS_NAME_IDENT = new RegExp(regexpu("((?:\\\\.|[A-Za-z_\\-\\u{00a0}-\\u{10ffff}])(?:\\\\.|[A-Za-z_\\-0-9\\u{00a0}-\\u{10ffff}])*)", "u"));
+// CSS <ident-token> Defined: https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
+export const CLASS_NAME_IDENT = new RegExp(regexpu("^(-?(?:\\\\.|[A-Za-z_\\u{0080}-\\u{10ffff}])(?:\\\\.|[A-Za-z0-9_\\-\\u{0080}-\\u{10ffff}])*)$", "u"));
 
 export enum BlockType {
   root = 1,

--- a/test/syntax-test.ts
+++ b/test/syntax-test.ts
@@ -426,6 +426,36 @@ export class BlockReferences extends BEMProcessor {
     });
   }
 
+  @test "block names in double quotes fail parse with helpful error"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource("foo/bar/imported.css",
+      `.root { block-name: "snow-flake"; }`
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block-reference "./imported.css";
+                    @block-debug snow-flake to comment;`;
+
+    return this.process(filename, inputCSS, {importer: imports.importer()}).catch((err) => {
+      assert.equal(err.message, "Illegal block name. '\"snow-flake\"' is not a legal CSS identifier. (foo/bar/imported.css:1:9)");
+    });
+  }
+
+  @test "block names in single quotes fail parse with helpful error"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource("foo/bar/imported.css",
+      `.root { block-name: 'snow-flake'; }`
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block-reference "./imported.css";
+                    @block-debug snow-flake to comment;`;
+
+    return this.process(filename, inputCSS, {importer: imports.importer()}).catch((err) => {
+      assert.equal(err.message, "Illegal block name. ''snow-flake'' is not a legal CSS identifier. (foo/bar/imported.css:1:9)");
+    });
+  }
+
   @test "block-name property only works in the root ruleset"() {
     let imports = new MockImportRegistry();
     imports.registerSource("foo/bar/imported.css",


### PR DESCRIPTION
 - Update CLASS_NAME_IDENT to fully adhere to w3 spec for <ident-token>.
 - Added link to spec documentation in comments.
 - Two new tests

Addresses issue #19 