### PR TITLE
Make BlockFactory actually cache its block singletons. 

### DIFF
--- a/src/Block/Block.ts
+++ b/src/Block/Block.ts
@@ -42,6 +42,8 @@ export class Block extends BlockObject {
   public readonly states: StateContainer;
   public readonly parsedRuleSelectors: WeakMap<postcss.Rule,ParsedSelector[]>;
 
+  private hasHadNameReset = false;
+
   constructor(name: string, identifier: FileIdentifier) {
     super(name);
     this._identifier = identifier;
@@ -49,6 +51,18 @@ export class Block extends BlockObject {
     this.states = new StateContainer(this);
     this._localScope = new BlockScope(this);
     this._dependencies = new Set<string>();
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  set name(name: string) {
+    if ( this.hasHadNameReset ) {
+      throw new CssBlockError('Can not set block name more than once.');
+    }
+    this._name = name;
+    this.hasHadNameReset = true;
   }
 
   /**

--- a/src/Block/BlockFactory.ts
+++ b/src/Block/BlockFactory.ts
@@ -167,11 +167,14 @@ export class BlockFactory implements IBlockFactory {
         });
       });
     }).then(block => {
+
       // last check  to make sure we don't return a new instance
       if (this.blocks[block.identifier]) {
         return this.blocks[block.identifier];
       } else {
-        return block;
+        // Ensure this block name is unique.
+        block.name = this.getUniqueBlockName(block.name);
+        return this.blocks[block.identifier] = block;
       }
     }).catch((error) => {
       if (this.preprocessQueue.activeJobCount > 0) {

--- a/src/BlockCompiler/conflictDetection.ts
+++ b/src/BlockCompiler/conflictDetection.ts
@@ -1,5 +1,5 @@
-import { BlockObject } from "./Block";
-import { shorthandsFor, longhandsFor } from "./shortHandProps";
+import { BlockObject } from "../Block";
+import { shorthandsFor, longhandsFor } from "../shortHandProps";
 
 export type Conflict = [string, string];
 

--- a/src/BlockCompiler/index.ts
+++ b/src/BlockCompiler/index.ts
@@ -1,10 +1,10 @@
 import * as postcss from "postcss";
-import { PluginOptions } from "./options";
-import { OptionsReader } from "./OptionsReader";
-import { MergedObjectMap, Block } from "./Block";
+import { OptionsReader } from "../OptionsReader";
+import { PluginOptions } from "../options";
+import { MergedObjectMap, Block } from "../Block";
 import ConflictResolver from "./ConflictResolver";
-import { StyleAnalysis } from "./TemplateAnalysis/StyleAnalysis";
-import parseBlockDebug from "./parseBlockDebug";
+import { StyleAnalysis } from "../TemplateAnalysis/StyleAnalysis";
+import parseBlockDebug from "../parseBlockDebug";
 /**
  * Compiler that, given a Block will return a transformed AST
  * interface is `BlockParser.parse`.

--- a/src/BlockParser.ts
+++ b/src/BlockParser.ts
@@ -151,9 +151,6 @@ export default class BlockParser {
       return Promise.reject(e);
     }
 
-    // Ensure this block name is unique.
-    defaultName = this.factory.getUniqueBlockName(defaultName);
-
     // Create our new Block object and save reference to the raw AST
     let block = new Block(defaultName, identifier);
     block.root = root;
@@ -386,7 +383,7 @@ export default class BlockParser {
 
       let blockPromise: Promise<Block> = this.factory.getBlockRelative(block.identifier, importPath);
       let namedResult: Promise<[string, string, postcss.AtRule, Block]> = blockPromise.then((referencedBlock: Block): [string, string, postcss.AtRule, Block] => {
-        return [localName || referencedBlock.name, importPath, atRule, referencedBlock];
+        return [localName, importPath, atRule, referencedBlock];
       });
       namedBlockReferences.push(namedResult);
     });


### PR DESCRIPTION
 - BlockFactory never actually saved compiled blocks in its cache. It does now.
 - Blocks are assigned unique names at the last possible moment to protect against race conditions.
 - Moved BlockParser and conflict utils to its own package directory for better organization.