### PR TITLE
Change the zombie emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ With css-blocks added to your project, you receive:
  - 🔥 Blazing Fast Stylesheets
  - 🚀 Project-Wide Optimization
  - 🚨 Build Time CSS Errors
- - 🧟‍♂️ Dead Code Elimination
+ - 🧟 Dead Code Elimination
  - ✨ Object Oriented Inheritance
 
 But, most importantly, CSS Blocks is **⚡️Statically Analyzable**.

--- a/packages/@css-blocks/website/src/pages/Home/index.tsx
+++ b/packages/@css-blocks/website/src/pages/Home/index.tsx
@@ -41,7 +41,7 @@ class Home extends Component {
             <li>🔥 Blazing Fast Stylesheets</li>
             <li>🚀 Project-Wide Optimization</li>
             <li>🚨 Build Time CSS Errors</li>
-            <li>🧟‍♂️ Dead Code Elimination</li>
+            <li>🧟 Dead Code Elimination</li>
             <li>✨ Object Oriented Inheritance</li>
           </ul>
 


### PR DESCRIPTION
The zombie emoji doesn't look quite right on Windows.
I assume any system that doesn't have the male/female zombie modifiers will also have this issue.

![zombie](https://user-images.githubusercontent.com/229881/39214222-bc53ab4a-47e1-11e8-988f-ea9416568bca.png)


This makes the zombie gender-neutral so readers can focus on the dead code elimination part 😉 