### PR TITLE
Fixes root state comment on README

### DIFF
--- a/packages/@css-blocks/jsx/README.md
+++ b/packages/@css-blocks/jsx/README.md
@@ -37,7 +37,7 @@ To reference sub-states on a state, pass the sub-state value as the first (and o
 ```jsx
 import styles from "my-block.block.css";
 
-// References the sub-state `.myClass[state|rootState="foo"]` from the imported block.
+// References the sub-state `:scope[state|rootState="foo"]` from the imported block.
 <div className={styles.rootState("foo")} />;
 
 // References the sub-state `.myClass[state|classState="bar"]` from the imported block.

--- a/packages/@css-blocks/jsx/README.md
+++ b/packages/@css-blocks/jsx/README.md
@@ -22,7 +22,7 @@ import styles from "my-block.block.css";
 // References the class `.myClass` from the imported block.
 <div className={styles.myClass} />;
 
-// References the state `.myClass[state|rootState]` from the imported block.
+// References the state `:scope[state|rootState]` from the imported block.
 <div className={styles.rootState()} />;
 
 // References the state `.myClass[state|classState]` from the imported block.


### PR DESCRIPTION
My guess is that for `.myClass[state|rootState]` the code would be `styles.myClass.rootState()`, but the code is `styles.rootState()`, so I believe the documentation comment is incorrect and should change as stated by the PR.