### PR TITLE
Improve docs for webpack and jsx

### DIFF
--- a/packages/@css-blocks/jsx/README.md
+++ b/packages/@css-blocks/jsx/README.md
@@ -83,8 +83,9 @@ let styleOne = objstr({
 The JSX Analyzer extends the main CSS Blocks core Analyzer. Its constructor accepts a unique name, to help with debugging, and an options hash:
 
 ```js
-import { Analyzer } from "@css-blocks/jsx";
-let analyzer = new Analyzer("unique-name", options);
+
+const CssBlocks = require("@css-blocks/jsx");
+const CssBlockAnalyzer = new CssBlocks.Analyzer(paths.appIndexJs, jsxCompilationOptions);
 ```
 
 Possible options are:

--- a/packages/@css-blocks/webpack/README.md
+++ b/packages/@css-blocks/webpack/README.md
@@ -25,9 +25,9 @@ module.exports =  {
     new CssBlocksPlugin({
       name: "css-blocks",
       outputCssFile: "my-output-file.css",
-      analyzer: analyzerInstance,
-      compilationOptions: cssBlocksCompilationOptions,
-      optimization: opticssOptimizationOptions
+      analyzer: CssBlockAnalyzer,
+      compilationOptions: {},
+      optimization: {}
     }),
     /* ... */
   ],
@@ -62,8 +62,8 @@ module.exports =  {
           {
             loader: require.resolve("@css-blocks/webpack/dist/src/loader"),
             options: {
-              analyzer: analyzerInstance,
-              rewriter: sharedDataObject
+              analyzer: CssBlockAnalyzer,
+              rewriter: CssBlockRewriter
             }
           },
         ]
@@ -81,6 +81,19 @@ Each template integration's rewriter is slightly different and must be integrate
 However, Webpack will typically be used with CSS Blocks' JSX integration. The typical JSX end-to-end integration with webpack looks like this:
 
 ```js
+
+const jsxCompilationOptions = {
+  compilationOptions: {},
+  types: "none",
+  aliases: {},
+  optimization: {
+    rewriteIdents: true,
+    mergeDeclarations: true,
+    removeUnusedStyles: true,
+    conflictResolution: true,
+    enabled: false,
+  },
+};
 
 const CssBlocks = require("@css-blocks/jsx");
 const CssBlocksPlugin = require("@css-blocks/webpack").CssBlocksPlugin;
@@ -122,8 +135,8 @@ module.exports =  {
           {
             loader: require.resolve("@css-blocks/webpack/dist/src/loader"),
             options: {
-              analyzer: analyzerInstance,
-              rewriter: sharedRewriterData
+              analyzer: CssBlockAnalyzer,
+              rewriter: CssBlockRewriter
             }
           },
         ]


### PR DESCRIPTION
I made the JSX consistent with the Webpack examples.

Also brought more "ghost"/"undefined" variables into the snippets. I am not sure if this is more confusing but it still follows the consistency of using create-react-app varialbes (i.e. the paths.indexJs).