### PR TITLE
Adding first acceptance tests to @css-blocks/ember-cli

### DIFF
--- a/packages/@css-blocks/ember-cli/package.json
+++ b/packages/@css-blocks/ember-cli/package.json
@@ -16,7 +16,7 @@
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests",
     "start": "ember serve",
-    "test": "ember test",
+    "test": "EMBER_CLI_MODULE_UNIFICATION=true ember test",
     "test:all": "ember try:each"
   },
   "dependencies": {

--- a/packages/@css-blocks/ember-cli/package.json
+++ b/packages/@css-blocks/ember-cli/package.json
@@ -44,6 +44,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-native-dom-helpers": "^0.6.2",
     "ember-resolver": "^4.0.0",
     "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/5431f71df060e7b5c82c05c300f40e9151d135e8.tgz",
     "ember-source-channel-url": "^1.0.1",

--- a/packages/@css-blocks/ember-cli/tests/acceptance/styles-applied-test.js
+++ b/packages/@css-blocks/ember-cli/tests/acceptance/styles-applied-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { find } from 'ember-native-dom-helpers';
+
+module('Acceptance | styles applied', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('route stylesheet is applied', async function(assert) {
+    await visit('/posts/new');
+    assert.equal(getComputedStyle(find('[data-test="posts-new-h3"]')).color, 'rgb(0, 128, 0)');
+  });
+
+  test('block reference style is applied', async function(assert) {
+    await visit('/posts/new');
+    assert.equal(getComputedStyle(find('[data-test="posts-new-h3"]'))['font-style'], 'italic');
+  });
+});

--- a/packages/@css-blocks/ember-cli/tests/dummy/config/environment.js
+++ b/packages/@css-blocks/ember-cli/tests/dummy/config/environment.js
@@ -48,6 +48,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
   }
 
   if (environment === 'production') {

--- a/packages/@css-blocks/ember-cli/tests/dummy/src/ui/routes/posts/new/template.hbs
+++ b/packages/@css-blocks/ember-cli/tests/dummy/src/ui/routes/posts/new/template.hbs
@@ -2,5 +2,6 @@
   class="typography"
   state:typography.bold
   state:typography.italic
+  data-test="posts-new-h3"
 >Posts – New</h3>
 {{outlet}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5160,6 +5160,13 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-native-dom-helpers@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.6.0"
+
 ember-qunit@^3.3.2:
   version "3.4.0"
   resolved "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.4.0.tgz#47a60c2b889cd4b4a46380bf9da2b10115c0eae7"


### PR DESCRIPTION
This makes acceptance tests work in the dummy app and adds two simple ones. I was going to add more tests, but I realized I'm unclear on what the right semantics are here. 

1. The current code doesn't seem to be aware of the wrapping element that Ember applies to classic components by default. An example of the wrong behavior is `local-component`, which is getting turned yellow as it should, but the style is being applied at the wrong level (the component's true root element is the parent of the div that appears in its template). Personally, I'd be fine with css-blocks only supporting components that don't have a wrapping div (which is possible today either by enabling the template-only glimmer components optional feature or by setting `tagName` to ""), but if so we should at least try to warn people when they're doing the wrong thing.

2. Fragmentary templates (ones with zero or many top-level elements) are supported and encouraged. For example, the application template in this addon's dummy app is fragmentary (it has no root element). Components are also allowed to be fragmentary (and this will be even easier to do going forward, once components with an automatic wrapping div stop being the default).

It looks to me like there are two things css-blocks can do to work pleasantly with fragmentary components:

 1. Tolerate not having a real root element so long as nobody is trying to apply styles to the `:scope` selector. A template with many top-level elements can accompany a stylesheet with many literal class selectors and the result is unambiguous, and can still benefit from css-block's forced encapsulation and optimizations.

 2. Allow the root element to be designated via syntax within the template. This is probably not a css-blocks framework-level feature, just an addition to the glimmer template analyzer. When a root element is explicitly designated, that would unlock usage of the `:scope` selector. A syntax for designating the root element is something we already plan to need in glimmer components for multiple other purposes  (like designating where to put HTML attributes or event handlers that callers try to apply to your component).
