### PR TITLE
feat: In-Stylesheet Block Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ CSS Blocks is under active development and there are a number of features that h
 | ✅ | `block-name: "custom-name";` | Provide custom Block names in `:scope` for a nicer debugging experience. |
 | ✅ | `implements: block-name;` | A Block can declare that it implements one or more other Block's interfaces in its `:scope` selector and the compiler will ensure that all of those states and classes are styled locally. |
 | ✅ | `extends: block-name;` | A Block may specify it extends another Block in its `:scope` selector to inherit and extend all the class and state implementations therein. |
-| 🖌 | `apply: "block.path";` | Mixin-Style class and state composition. Apply other Blocks' Styles to one of yours.  |
+| ✅ | `composes: "block.path";` | Mixin-Style class and state composition. Apply other Blocks' Styles to one of yours.  |
 | **Functions** ||
 | ✅ | `resolve("block.path");` | Provide an explicit resolution for a given property against another Block. |
 | ❌ | `constrain(val1, val2 ... valN);` | Constrain this property to a list of specific values that may be set when this Block is extended. |

--- a/packages/@css-blocks/core/src/Analyzer/ElementAnalysis.ts
+++ b/packages/@css-blocks/core/src/Analyzer/ElementAnalysis.ts
@@ -441,14 +441,14 @@ export class ElementAnalysis<BooleanExpression, StringExpression, TernaryExpress
           // If we should always apply these conditions, statically apply what makes sense for the BlockObj.
           else if (conditions === true) {
             if (isAttrValue(comp.style)) {
-              this.addStaticClass(comp.style.blockClass);
-              this.addStaticAttr(comp.style.blockClass, comp.style);
+              this.addedStyles.push({ klass: comp.style.blockClass });
+              this.addedStyles.push({ container: comp.style.blockClass, value: new Set([comp.style]) });
             }
             else {
-              this.addStaticClass(comp.style);
+              this.addedStyles.push({ klass: comp.style });
             }
           }
-          // Otherwise, these styles will be applied under these certian conditions.
+          // Otherwise, these styles will be applied under these certain conditions.
           else {
             this.addedStyles.push({
               value,
@@ -629,30 +629,16 @@ export class ElementAnalysis<BooleanExpression, StringExpression, TernaryExpress
   }
 
   /**
-   * this maps the class and all the classes that the explicit class implies
+   * Map the class and all the classes that the explicit class implies
    * to all the blocks those classes belong to via inheritance.
    *
    * These classes become valid containers for AttrValues even if they are not
    * explicitly set on the element.
    */
   private mapBlocksForClass(klass: BlockClass) {
-    let explicitBlock = klass.block;
-    let blockHierarchy = new Set(explicitBlock.getAncestors());
-    blockHierarchy.add(explicitBlock);
-    let resolvedStyles = klass.resolveStyles();
-    for (let style of resolvedStyles) {
-      if (!isBlockClass(style)) continue;
-      let implicitBlock = style.block;
-      let hierarchy: Set<Block>;
-      if (blockHierarchy.has(implicitBlock)) {
-        hierarchy = blockHierarchy;
-      } else {
-        hierarchy = new Set(implicitBlock.getAncestors());
-        hierarchy.add(implicitBlock);
-      }
-      for (let block of hierarchy) {
-        this.allClasses.set(block, style);
-      }
+    this.allClasses.set(klass.block, klass);
+    for (let otherClass of klass.resolveInheritance()) {
+      this.allClasses.set(otherClass.block, otherClass);
     }
   }
 

--- a/packages/@css-blocks/core/src/Analyzer/validations/attribute-group-validator.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/attribute-group-validator.ts
@@ -28,20 +28,26 @@ function ensureUniqueAttributeGroup(discovered: Set<Attribute>, group: Attribute
 export const attributeGroupValidator: Validator = (analysis, _templateAnalysis, err) => {
   let discovered: Set<Attribute> = new Set();
   for (let o of analysis.static) {
-    if (isAttrValue(o)) {
+    if (isAttrValue(o) && !analysis.isFromComposition(o)) {
       ensureUniqueAttributeGroup(discovered, o.attribute, err, true);
     }
   }
   for (let stat of analysis.dynamicAttributes) {
     if (isBooleanAttr(stat)) {
-      ensureUniqueAttributeGroup(discovered, stat.value.attribute, err, true);
+      for (let val of stat.value) {
+        if (isAttrValue(val) && !analysis.isFromComposition(val)) {
+          ensureUniqueAttributeGroup(discovered, val.attribute, err, true);
+        }
+      }
     }
     if (isAttrGroup(stat)) {
       let tmp: Set<Attribute> = new Set();
       for (let key of Object.keys(stat.group)) {
         let attr = stat.group[key];
-        let values = ensureUniqueAttributeGroup(discovered, attr.attribute, err, false);
-        values.forEach((o) => tmp.add(o));
+        if (isAttrValue(attr) && !analysis.isFromComposition(attr)) {
+          let values = ensureUniqueAttributeGroup(discovered, attr.attribute, err, false);
+          values.forEach((o) => tmp.add(o));
+        }
       }
       unionInto(discovered, tmp);
     }

--- a/packages/@css-blocks/core/src/Analyzer/validations/attribute-parent-validator.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/attribute-parent-validator.ts
@@ -8,7 +8,7 @@ import { Validator } from "./Validator";
 
 export const attributeParentValidator: Validator = (analysis, _templateAnalysis, err) => {
   for (let attr of analysis.attributesFound()) {
-    if (!analysis.hasClass(attr.blockClass)) {
+    if (!analysis.hasClass(attr.blockClass) && !analysis.isFromComposition(attr.blockClass)) {
       err(`Cannot use state "${attr.asSource()}" without parent ` +
           `${ attr.blockClass.isRoot ? "block" : "class" } also applied or implied by another style.`);
     }

--- a/packages/@css-blocks/core/src/Analyzer/validations/class-pairs-validator.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/class-pairs-validator.ts
@@ -9,10 +9,10 @@ import { ErrorCallback, Validator } from "./Validator";
  */
 
 export const classPairsValidator: Validator = (analysis, _templateAnalysis, err) => {
-  // TODO: this doesn't work for dynamic classes
   let classPerBlock: Map<Block, BlockClass> = new Map();
   for (let container of analysis.classesFound(false)) {
     if (isBlockClass(container)) {
+      if (analysis.isFromComposition(container)) { continue; }
       for (let block of checkExisting(classPerBlock, classPerBlock, container, err)) {
         classPerBlock.set(block, container);
       }
@@ -22,6 +22,7 @@ export const classPairsValidator: Validator = (analysis, _templateAnalysis, err)
     let trueBlocks = new Map<Block, BlockClass>();
     if (isTrueCondition(dyn)) {
       for (let container of dyn.whenTrue) {
+        if (analysis.isFromComposition(container)) { continue; }
         if (isBlockClass(container)) {
           let blocks = checkExisting(classPerBlock, trueBlocks, container, err);
           for (let block of blocks) { trueBlocks.set(block, container); }
@@ -32,6 +33,7 @@ export const classPairsValidator: Validator = (analysis, _templateAnalysis, err)
     if (isFalseCondition(dyn)) {
       for (let container of dyn.whenFalse) {
         if (isBlockClass(container)) {
+          if (analysis.isFromComposition(container)) { continue; }
           let blocks = checkExisting(classPerBlock, falseBlocks, container, err);
           for (let block of blocks) { trueBlocks.set(block, container); }
         }

--- a/packages/@css-blocks/core/src/Analyzer/validations/property-conflict-validator.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/property-conflict-validator.ts
@@ -2,13 +2,13 @@ import { MultiMap, TwoKeyMultiMap, objectValues, whatever } from "@opticss/util"
 import * as propParser from "css-property-parser";
 import { postcss } from "opticss";
 
-import { isBlockClass, Ruleset, Style, BlockClass } from "../../BlockTree";
+import { AttrValue, BlockClass, Ruleset, Style, isBlockClass } from "../../BlockTree";
 import {
+  ElementAnalysis,
   isAttrGroup,
   isBooleanAttr,
   isFalseCondition,
   isTrueCondition,
-  ElementAnalysis,
 } from "../ElementAnalysis";
 
 import { Validator } from "./Validator";
@@ -128,7 +128,7 @@ function inStylesheetComposition(
   analysis: ElementAnalysis<whatever, whatever, whatever>,
   conflicts: ConflictMap,
   allConditions: PropMap,
-){
+) {
   composed: for (let composed of blockClass.composedStyles()) {
     for (let condition of composed.conditions) {
       if (!analysis.hasAttribute(condition)) { break composed; }
@@ -202,8 +202,10 @@ export const propertyConflictValidator: Validator = (elAnalysis, _templateAnalys
     }
 
     else if (isBooleanAttr(condition)) {
-      evaluate(condition.value, allConditions, conflicts);
-      add(allConditions, condition.value);
+      for (let val of condition.value) {
+        evaluate(val as AttrValue, allConditions, conflicts);
+        add(allConditions, val as AttrValue);
+      }
     }
   });
 

--- a/packages/@css-blocks/core/src/Analyzer/validations/root-class-validator.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/root-class-validator.ts
@@ -14,7 +14,7 @@ export const rootClassValidator: Validator = (analysis, templateAnalysis, err) =
       foundClass = foundClass || !container.isRoot;
     }
     if (foundRoot && foundClass) {
-      err(`Cannot put block classes on the block's root element`);
+      err(`Cannot put Block classes on the Block's root element.`);
     }
   }
 };

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -75,8 +75,8 @@ export class BlockCompiler {
     root.walkAtRules(BLOCK_DEBUG, (atRule) => {
       let {block: ref, channel} = parseBlockDebug(atRule, sourceFile, block);
       if (channel === "comment") {
-        let debugStr = ref.debug(this.config);
-        atRule.replaceWith(this.postcss.comment({text: debugStr.join("\n   ")}));
+        let text = `${ref.debug(this.config).join('\n * ')}\n`;
+        atRule.replaceWith(this.postcss.comment({ text }));
       } else {
         // stderr/stdout are emitted during parse.
         atRule.remove();

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -75,7 +75,7 @@ export class BlockCompiler {
     root.walkAtRules(BLOCK_DEBUG, (atRule) => {
       let {block: ref, channel} = parseBlockDebug(atRule, sourceFile, block);
       if (channel === "comment") {
-        let text = `${ref.debug(this.config).join('\n * ')}\n`;
+        let text = `${ref.debug(this.config).join("\n * ")}\n`;
         atRule.replaceWith(this.postcss.comment({ text }));
       } else {
         // stderr/stdout are emitted during parse.

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -7,8 +7,8 @@ import * as errors from "../errors";
 import { FileIdentifier } from "../importing";
 
 import { assertForeignGlobalAttribute } from "./features/assert-foreign-global-attribute";
-import { constructBlock } from "./features/construct-block";
 import { composeBlock } from "./features/composes-block";
+import { constructBlock } from "./features/construct-block";
 import { disallowImportant } from "./features/disallow-important";
 import { discoverName } from "./features/discover-name";
 import { exportBlocks } from "./features/export-blocks";

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -8,6 +8,7 @@ import { FileIdentifier } from "../importing";
 
 import { assertForeignGlobalAttribute } from "./features/assert-foreign-global-attribute";
 import { constructBlock } from "./features/construct-block";
+import { composeBlock } from "./features/composes-block";
 import { disallowImportant } from "./features/disallow-important";
 import { discoverName } from "./features/discover-name";
 import { exportBlocks } from "./features/export-blocks";
@@ -98,6 +99,8 @@ export class BlockParser {
     // Validate that all required Styles are implemented.
     debug(` - Implement Block`);
     await implementBlock(root, block, debugIdent);
+    // Register all block compositions.
+    await composeBlock(root, block, debugIdent);
     // Log any debug statements discovered.
     debug(` - Process Debugs`);
     await processDebugStatements(root, block, debugIdent, this.config);

--- a/packages/@css-blocks/core/src/BlockParser/block-intermediates.ts
+++ b/packages/@css-blocks/core/src/BlockParser/block-intermediates.ts
@@ -1,8 +1,8 @@
 import { assertNever, whatever } from "@opticss/util";
-import { postcssSelectorParser as selectorParser, CompoundSelector } from "opticss";
+import { CompoundSelector, postcssSelectorParser as selectorParser } from "opticss";
 
 import { ATTR_PRESENT, AttrToken, ROOT_CLASS, STATE_NAMESPACE } from "../BlockSyntax";
-import { Block, BlockClass, AttrValue } from "../BlockTree";
+import { AttrValue, Block, BlockClass } from "../BlockTree";
 
 export enum BlockType {
   block = 1,
@@ -146,7 +146,7 @@ export interface StyleTargets {
  */
 export function getStyleTargets(block: Block, sel: CompoundSelector): StyleTargets {
   let blockAttrs: AttrValue[] = [];
-  let blockClass: BlockClass;
+  let blockClass: BlockClass | undefined = undefined;
 
   for (let node of sel.nodes) {
     if (isRootNode(node)) {
@@ -157,13 +157,15 @@ export function getStyleTargets(block: Block, sel: CompoundSelector): StyleTarge
     }
     else if (isAttributeNode(node)) {
       // The fact that a base class exists for all state selectors is
-      // validated in `assertBlockObject`.
-      blockAttrs.push(blockClass!.ensureAttributeValue(toAttrToken(node)));
+      // validated in `assertBlockObject`. BlockClass may be undefined
+      // here if parsing a global state.
+      if (!blockClass) { continue; }
+      blockAttrs.push(blockClass.ensureAttributeValue(toAttrToken(node)));
     }
   }
 
   return {
     blockAttrs,
-    blockClasses: [ blockClass ],
+    blockClasses: blockClass ? [ blockClass ] : [],
   };
 }

--- a/packages/@css-blocks/core/src/BlockParser/block-intermediates.ts
+++ b/packages/@css-blocks/core/src/BlockParser/block-intermediates.ts
@@ -1,7 +1,8 @@
 import { assertNever, whatever } from "@opticss/util";
-import { postcssSelectorParser as selectorParser } from "opticss";
+import { postcssSelectorParser as selectorParser, CompoundSelector } from "opticss";
 
 import { ATTR_PRESENT, AttrToken, ROOT_CLASS, STATE_NAMESPACE } from "../BlockSyntax";
+import { Block, BlockClass, AttrValue } from "../BlockTree";
 
 export enum BlockType {
   block = 1,
@@ -126,4 +127,43 @@ export const isClassNode = selectorParser.isClassName;
  */
 export function isAttributeNode(node: selectorParser.Node): node is selectorParser.Attribute {
   return selectorParser.isAttribute(node) && node.namespace === STATE_NAMESPACE;
+}
+
+/**
+ * Describes all possible terminating styles in a CSS Blocks selector.
+ */
+export interface StyleTargets {
+  blockAttrs: AttrValue[];
+  blockClasses: BlockClass[];
+}
+
+/**
+ * Given a Block and ParsedSelector, return all terminating Style objects.
+ * These may be either a single `BlockClass` or 1 to many `AttrValue`s.
+ * @param block The Block to query against.
+ * @param sel The ParsedSelector
+ * @returns The array of discovered Style objects.
+ */
+export function getStyleTargets(block: Block, sel: CompoundSelector): StyleTargets {
+  let blockAttrs: AttrValue[] = [];
+  let blockClass: BlockClass;
+
+  for (let node of sel.nodes) {
+    if (isRootNode(node)) {
+      blockClass = block.rootClass;
+    }
+    else if (isClassNode(node)) {
+      blockClass = block.ensureClass(node.value);
+    }
+    else if (isAttributeNode(node)) {
+      // The fact that a base class exists for all state selectors is
+      // validated in `assertBlockObject`.
+      blockAttrs.push(blockClass!.ensureAttributeValue(toAttrToken(node)));
+    }
+  }
+
+  return {
+    blockAttrs,
+    blockClasses: [ blockClass ],
+  };
 }

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -1,11 +1,12 @@
 import { postcss } from "opticss";
+import { isRule } from "opticss/dist/src/util/cssIntrospection";
 
 import { COMPOSES } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
 import { sourceLocation } from "../../SourceLocation";
-import { isRule } from "opticss/dist/src/util/cssIntrospection";
 import { getStyleTargets } from "../block-intermediates";
+import { stripQuotes } from "../utils";
 
 /**
  * For each `composes` property found in the passed ruleset, track the foreign
@@ -20,7 +21,7 @@ export async function composeBlock(root: postcss.Root, block: Block, sourceFile:
     let rule = decl.parent;
 
     // TODO: Move to Block Syntax as parseBlockRefList().
-    let refNames = decl.value.split(/,\s*/);
+    let refNames = decl.value.split(/,\s*/).map(stripQuotes);
     for (let refName of refNames) {
       let refStyle = block.lookup(refName);
       if (!refStyle) {

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -41,5 +41,6 @@ export async function composeBlock(root: postcss.Root, block: Block, sourceFile:
         }
       }
     }
+    decl.remove();
   });
 }

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -1,0 +1,45 @@
+import { postcss } from "opticss";
+
+import { COMPOSES } from "../../BlockSyntax";
+import { Block } from "../../BlockTree";
+import * as errors from "../../errors";
+import { sourceLocation } from "../../SourceLocation";
+import { isRule } from "opticss/dist/src/util/cssIntrospection";
+import { getStyleTargets } from "../block-intermediates";
+
+/**
+ * For each `composes` property found in the passed ruleset, track the foreign
+ * block. If block is not found, throw.
+ * @param block  Block object being processed
+ * @param sourceFile  Source file name, used for error output.
+ * @param rule Ruleset to crawl
+ */
+export async function composeBlock(root: postcss.Root, block: Block, sourceFile: string) {
+  root.walkDecls(COMPOSES, (decl) => {
+    if (!isRule(decl.parent)) { throw new errors.InvalidBlockSyntax(`The "composes" property may only be used in a rule set.`, sourceLocation(sourceFile, decl)); }
+    let rule = decl.parent;
+
+    // TODO: Move to Block Syntax as parseBlockRefList().
+    let refNames = decl.value.split(/,\s*/);
+    for (let refName of refNames) {
+      let refStyle = block.lookup(refName);
+      if (!refStyle) {
+        throw new errors.InvalidBlockSyntax(`No style "${refName}" found.`, sourceLocation(sourceFile, decl));
+      }
+      if (refStyle.block === block) {
+        throw new errors.InvalidBlockSyntax(`Styles from the same Block may not be composed together.`, sourceLocation(sourceFile, decl));
+      }
+
+      const parsedSel = block.getParsedSelectors(rule);
+      for (let sel of parsedSel) {
+        if (sel.selector.next) {
+          throw new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a scope selector.`, sourceLocation(sourceFile, decl));
+        }
+        let foundStyles = getStyleTargets(block, sel.selector);
+        for (let blockClass of foundStyles.blockClasses) {
+          blockClass.addComposedStyle(refStyle, foundStyles.blockAttrs);
+        }
+      }
+    }
+  });
+}

--- a/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
@@ -7,13 +7,13 @@ import {
   BlockType,
   NodeAndType,
   blockTypeName,
+  getStyleTargets,
   isAttributeNode,
   isClassLevelObject,
   isClassNode,
   isExternalBlock,
   isRootLevelObject,
   isRootNode,
-  getStyleTargets,
 } from "../block-intermediates";
 
 const SIBLING_COMBINATORS = new Set(["+", "~"]);

--- a/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
@@ -93,7 +93,7 @@ export async function constructBlock(root: postcss.Root, block: Block, file: str
   });
 
   // To allow self-referential block lookup when constructing ruleset concerns,
-  // we need to run `addRuleset()` only *after* all Style have been created.
+  // we need to run `addRuleset()` only *after* all Styles have been created.
   for (let [style, rule] of styleRuleTuples) {
     style.rulesets.addRuleset(file, rule);
   }

--- a/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
@@ -83,8 +83,11 @@ export async function constructBlock(root: postcss.Root, block: Block, file: str
 
         // If this is the key selector, save this ruleset on the created style.
         if (isKey) {
-          foundStyles.blockClasses.map(s => styleRuleTuples.add([s, rule]));
-          foundStyles.blockAttrs.map(s => styleRuleTuples.add([s, rule]));
+          if (foundStyles.blockAttrs.length) {
+            foundStyles.blockAttrs.map(s => styleRuleTuples.add([s, rule]));
+          } else {
+            foundStyles.blockClasses.map(s => styleRuleTuples.add([s, rule]));
+          }
         }
 
         sel = sel.next && sel.next.selector;

--- a/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
@@ -6,18 +6,9 @@ import * as errors from "../../errors";
 import { sourceLocation } from "../../SourceLocation";
 
 import { BlockFactory } from "../index";
-import { parseBlockNames } from "../utils/blockNamesParser";
+import { parseBlockNames, stripQuotes } from "../utils";
 
 const FROM_EXPR = /\s+from\s+/;
-
-/**
- * Strip matching quotes from the beginning and end of a string
- * @param str String to strip quotes from
- * @return Result
- */
-function stripQuotes(str: string): string {
-  return str.replace(/^(["'])(.+)\1$/, "$2");
-}
 
 /**
  * Resolve all block references for a given block.

--- a/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
@@ -60,7 +60,6 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
           );
         }
         let localName = blockNames[remoteName];
-        console.log(remoteName, localName, block.identifier);
         if (!CLASS_NAME_IDENT.test(localName)) {
           throw new errors.InvalidBlockSyntax(
             `Illegal block name in export. "${localName}" is not a legal CSS identifier.`,

--- a/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
@@ -7,18 +7,9 @@ import * as errors from "../../errors";
 import { sourceLocation } from "../../SourceLocation";
 
 import { BlockFactory } from "../index";
-import { parseBlockNames } from "../utils/blockNamesParser";
+import { parseBlockNames, stripQuotes } from "../utils";
 
 const FROM_EXPR = /\s+from\s+/;
-
-/**
- * Strip matching quotes from the beginning and end of a string
- * @param str String to strip quotes from
- * @return Result
- */
-function stripQuotes(str: string): string {
-  return str.replace(/^(["'])(.+)\1$/, "$2");
-}
 
 /**
  * Resolve all block references for a given block.

--- a/packages/@css-blocks/core/src/BlockParser/utils/index.ts
+++ b/packages/@css-blocks/core/src/BlockParser/utils/index.ts
@@ -1,0 +1,2 @@
+export { BlockNames, parseBlockNames } from "./blockNamesParser";
+export { stripQuotes } from "./stripQuotes";

--- a/packages/@css-blocks/core/src/BlockParser/utils/stripQuotes.ts
+++ b/packages/@css-blocks/core/src/BlockParser/utils/stripQuotes.ts
@@ -1,0 +1,8 @@
+/**
+ * Strip matching quotes from the beginning and end of a string
+ * @param str String to strip quotes from
+ * @return Result
+ */
+export function stripQuotes(str: string): string {
+  return str.replace(/^(["'])(.+)\1$/, "$2");
+}

--- a/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
@@ -253,7 +253,7 @@ export class BlockPath {
         // If the end of an attribute, set the attribute token we've been working on and finish.
         case char === ATTR_END:
           if (!isAttribute(token)) { return this.throw(ERRORS.illegalCharNotInAttribute(char)); }
-          if ((!hasName(token) || !isQuoted(token)) && !isIdent(working)) {
+          if (hasName(token) && !isQuoted(token) && !isIdent(working)) {
             return this.throw(ERRORS.invalidIdent(working), working.length);
           }
           (hasName(token)) ? (token.value = working) : (token.name = working);

--- a/packages/@css-blocks/core/src/BlockSyntax/BlockSyntax.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/BlockSyntax.ts
@@ -13,8 +13,9 @@ export const STATE_NAMESPACE = "state";
 export const EXTENDS = "extends";
 export const IMPLEMENTS = "implements";
 export const BLOCK_NAME = "block-name";
-export const BLOCK_PROP_NAMES = new Set([BLOCK_NAME, EXTENDS, IMPLEMENTS]);
-export const BLOCK_PROP_NAMES_RE = /^(extends|implements|block-name)$/;
+export const COMPOSES = "composes";
+export const BLOCK_PROP_NAMES = new Set([BLOCK_NAME, EXTENDS, IMPLEMENTS, COMPOSES]);
+export const BLOCK_PROP_NAMES_RE = /^(extends|implements|block-name|composes)$/;
 
 // At Rules
 export const BLOCK_DEBUG = "block-debug";

--- a/packages/@css-blocks/core/src/BlockTree/AttrValue.ts
+++ b/packages/@css-blocks/core/src/BlockTree/AttrValue.ts
@@ -75,14 +75,22 @@ export class AttrValue extends Style<AttrValue, Block, Attribute, never> {
   }
 
   /**
+   * Return the bare AttrValue name.
+   * @returns String representing AttrValue.
+   */
+  name(): string {
+    let namespace = this.attribute.namespace ? `${this.attribute.namespace}|` : "";
+    let value = (this.value && this.value !== ATTR_PRESENT) ? `=${this.value}` : "";
+    return `[${namespace}${this.parent.name}${value}]`;
+  }
+
+  /**
    * Export as original AttrValue name.
    * @param scope  Optional scope to resolve this name relative to. If `true`, return the Block name instead of `:scope`. If a Block object, return with the local name instead of `:scope`.
    * @returns String representing original AttrValue path.
    */
   asSource(scope?: Block | boolean): string {
-    let namespace = this.attribute.namespace ? `${this.attribute.namespace}|` : "";
-    let value = (this.value && this.value !== ATTR_PRESENT) ? `=${this.value}` : "";
-    return this.attribute.blockClass.asSource(scope) + `[${namespace}${this.parent.name}${value}]`;
+    return this.attribute.blockClass.asSource(scope) + this.name();
   }
 
   public cssClass(config: ResolvedConfiguration): string {

--- a/packages/@css-blocks/core/src/BlockTree/AttrValue.ts
+++ b/packages/@css-blocks/core/src/BlockTree/AttrValue.ts
@@ -6,7 +6,7 @@ import {
 } from "@opticss/element-analysis";
 import { assertNever, assertNeverCalled } from "@opticss/util";
 
-import { ATTR_PRESENT } from "../BlockSyntax";
+import { ATTR_PRESENT, CLASS_NAME_IDENT } from "../BlockSyntax";
 import { OutputMode,
  ResolvedConfiguration } from "../configuration";
 
@@ -15,6 +15,8 @@ import { Block } from "./Block";
 import { BlockClass } from "./BlockClass";
 import { RulesetContainer } from "./RulesetContainer";
 import { Style } from "./Style";
+
+const isIdent = (ident?: string): boolean => !ident || CLASS_NAME_IDENT.test(ident);
 
 /**
  * AttrValue represents the value of an Attribute in a particular Block.
@@ -80,7 +82,7 @@ export class AttrValue extends Style<AttrValue, Block, Attribute, never> {
    */
   name(): string {
     let namespace = this.attribute.namespace ? `${this.attribute.namespace}|` : "";
-    let value = (this.value && this.value !== ATTR_PRESENT) ? `=${this.value}` : "";
+    let value = (this.value && this.value !== ATTR_PRESENT) ? isIdent(this.value) ? `=${this.value}` : `="${this.value}"` : "";
     return `[${namespace}${this.parent.name}${value}]`;
   }
 

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -446,14 +446,20 @@ export class Block
   }
 
   debug(config: ResolvedConfiguration): string[] {
-    let result: string[] = [`Source: ${this.identifier}`, this.rootClass.asDebug(config)];
-    let sourceNames = new Set<string>(this.all().map(s => s.asSource()));
-    let sortedNames = [...sourceNames].sort();
+    let result: string[] = [`Source: ${this.identifier}`];
+
+    // Log Root Class and all children first at root level.
+    result.push(ROOT_CLASS, ...this.rootClass.debug(config));
+
+    // Log all BlockClasses and children at second level.
+    let sourceNames = new Set<string>(this.resolveChildren().map(s => s.asSource()));
+    let sortedNames = [...sourceNames].sort().filter((n) => n !== ROOT_CLASS);
     for (let n of sortedNames) {
-      if (n !== ROOT_CLASS) {
-        let o = this.find(n) as Styles;
-        result.push(o.asDebug(config));
-      }
+      const isLast = n.indexOf(n) === sortedNames.length - 1;
+      let o = this.find(n) as BlockClass;
+      result.push(` ${isLast ? "└──"  : "├──"} ${o.asDebug(config)}`);
+      const childrenDebugs = o.debug(config).map((s) => ` ${isLast ? " " : "|"}   ${s}`);
+      result.push(...childrenDebugs);
     }
     return result;
   }

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -449,13 +449,14 @@ export class Block
     let result: string[] = [`Source: ${this.identifier}`];
 
     // Log Root Class and all children first at root level.
-    result.push(ROOT_CLASS, ...this.rootClass.debug(config));
+    const classes = this.rootClass.cssClasses(config).join(".");
+    result.push(`${ROOT_CLASS} (.${classes})`, ...this.rootClass.debug(config));
 
     // Log all BlockClasses and children at second level.
     let sourceNames = new Set<string>(this.resolveChildren().map(s => s.asSource()));
     let sortedNames = [...sourceNames].sort().filter((n) => n !== ROOT_CLASS);
     for (let n of sortedNames) {
-      const isLast = n.indexOf(n) === sortedNames.length - 1;
+      const isLast = sortedNames.indexOf(n) === sortedNames.length - 1;
       let o = this.find(n) as BlockClass;
       result.push(` ${isLast ? "└──"  : "├──"} ${o.asDebug(config)}`);
       const childrenDebugs = o.debug(config).map((s) => ` ${isLast ? " " : "|"}   ${s}`);

--- a/packages/@css-blocks/core/src/BlockTree/BlockClass.ts
+++ b/packages/@css-blocks/core/src/BlockTree/BlockClass.ts
@@ -283,11 +283,12 @@ export class BlockClass extends Style<BlockClass, Block, Block, Attribute> {
       result.push(` ${isLast ? "└──"  : "├──"} ${comp.style.asSource(true)}${conditional}`);
     }
 
-    const children = [...this.resolveAttributeValues().values()].map(s => s.asDebug(config));
+    const children = [...this.resolveAttributeValues().values()].map(s => s.asSource());
     children.sort();
     if (children.length) { result.push(" states:"); }
     for (let n of children) {
-      let o = this.getAttributeValue(n)!;
+      let o = this.resolveAttributeValue(n);
+      if (!o) { continue; }
       let isLast = children.indexOf(n) === children.length - 1;
       result.push(` ${isLast ? "└──"  : "├──"} ${o.asDebug(config)}`);
     }

--- a/packages/@css-blocks/core/src/BlockTree/Inheritable.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Inheritable.ts
@@ -288,7 +288,7 @@ export abstract class Inheritable<
    * TypeScript can't figure out that `this` is the `Self` so this private
    * method casts it in a few places where it's needed.
    */
-  private asSelf(): Self {
+  protected asSelf(): Self {
     return <Self><object>this;
   }
 

--- a/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
+++ b/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
@@ -150,16 +150,19 @@ export class RulesetContainer<S extends Styles> {
    * @param  pseudo  Optional pseudo element to get Rulesets for
    * @returns A set of Ruleset objects.
    */
-  getRulesets(prop: string, pseudo?: string): Set<Ruleset<S>> {
-    if (!pseudo) {
-      let res: Ruleset<S>[] = [];
-      for (let pseudo of this.getPseudos()) {
-        res = [...res, ...this.concerns.get(pseudo, prop)];
+  getRulesets(prop?: string, pseudo?: string): Set<Ruleset<S>> {
+    let res: Ruleset<S>[] = [];
+    let pseudos = pseudo ? [pseudo] : this.getPseudos();
+    if (!prop) {
+      for (let pseudo of pseudos) {
+        res = [...res, ...this.rules.get(pseudo)];
       }
       return new Set(res);
     }
-
-    return new Set(this.concerns.get(pseudo, prop));
+    for (let pseudo of pseudos) {
+      res = [...res, ...this.concerns.get(pseudo, prop)];
+    }
+    return new Set(res);
   }
 
   /**

--- a/packages/@css-blocks/core/src/BlockTree/Style.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Style.ts
@@ -81,7 +81,7 @@ export abstract class Style<
 
     let inheritedStyles = this.resolveInheritance();
     this._resolvedStyles = new Set(inheritedStyles);
-
+    this._resolvedStyles.add(this.asSelf());
     return new Set(this._resolvedStyles);
   }
 
@@ -91,8 +91,8 @@ export abstract class Style<
    * @returns A debug string.
    */
   asDebug(config: ResolvedConfiguration) {
-    const classes = this.cssClasses(config).map(n => `.${n}`).join(" ");
-    return `${this.asSource()}${classes ? ` (${classes})` : ""}`;
+    const classes = this.cssClasses(config).join(".");
+    return `${this.asSource()}${classes ? ` (.${classes})` : ""}`;
   }
 
 }

--- a/packages/@css-blocks/core/src/BlockTree/Style.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Style.ts
@@ -91,7 +91,8 @@ export abstract class Style<
    * @returns A debug string.
    */
   asDebug(config: ResolvedConfiguration) {
-    return `${this.asSource()} => ${this.cssClasses(config).map(n => `.${n}`).join(" ")}`;
+    const classes = this.cssClasses(config).map(n => `.${n}`).join(" ");
+    return `${this.asSource()}${classes ? ` (${classes})` : ""}`;
   }
 
 }

--- a/packages/@css-blocks/core/src/BlockTree/Style.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Style.ts
@@ -1,11 +1,9 @@
 import { Attr } from "@opticss/element-analysis";
 
 import { ResolvedConfiguration } from "../configuration";
-import { unionInto } from "../util/unionInto";
 
 import { AnyNode, Inheritable } from "./Inheritable";
 import { RulesetContainer } from "./RulesetContainer";
-
 export { RulesetContainer, Resolution, Ruleset } from "./RulesetContainer";
 
 /**
@@ -73,8 +71,8 @@ export abstract class Style<
    * This takes inheritance, attr/class correlations, and any
    * other declared links between styles into account.
    *
-   * This block object is included in the returned result so the
-   * resolved value's size is always 1 or greater.
+   * This Block Object itself is included in the returned result
+   * so the resolved value's size is always 1 or greater.
    */
   public resolveStyles(): Set<Self> {
     if (this._resolvedStyles) {
@@ -83,27 +81,8 @@ export abstract class Style<
 
     let inheritedStyles = this.resolveInheritance();
     this._resolvedStyles = new Set(inheritedStyles);
-    this._resolvedStyles.add(this.asStyle());
-
-    for (let s of inheritedStyles) {
-      let implied = s.impliedStyles();
-      if (!implied) continue;
-      for (let i of implied) {
-        unionInto(this._resolvedStyles, i.resolveStyles());
-      }
-    }
 
     return new Set(this._resolvedStyles);
-  }
-
-  /**
-   * Returns the styles that are implied by this style.
-   * TODO: Placeholder for when we implement class composition. (https://github.com/linkedin/css-blocks/issues/72)
-   *
-   * @returns The Style objects, or undefined if no styles are implied.
-   */
-  impliedStyles(): Set<Self> | undefined {
-    return undefined;
   }
 
   /**
@@ -115,9 +94,4 @@ export abstract class Style<
     return `${this.asSource()} => ${this.cssClasses(config).map(n => `.${n}`).join(" ")}`;
   }
 
-  // TypeScript can't figure out that `this` is the `StyleType` so this private
-  // method casts it in a few places where it's needed.
-  private asStyle(): Self {
-    return <Self><object>this;
-  }
 }

--- a/packages/@css-blocks/core/src/BlockTree/index.ts
+++ b/packages/@css-blocks/core/src/BlockTree/index.ts
@@ -1,5 +1,5 @@
 export { Block, isBlock } from "./Block";
-export { BlockClass, isBlockClass } from "./BlockClass";
+export { BlockClass, Composition, isBlockClass } from "./BlockClass";
 export { Attribute, isAttribute } from "./Attribute";
 export { AttrValue, isAttrValue } from "./AttrValue";
 export { Ruleset, RulesetContainer } from "./RulesetContainer";

--- a/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
@@ -1,0 +1,117 @@
+import { assert } from "chai";
+import { suite, test, only } from "mocha-typescript";
+
+import { assertError } from "../util/assertError";
+import { BEMProcessor } from "../util/BEMProcessor";
+import { MockImportRegistry } from "../util/MockImportRegistry";
+
+const { InvalidBlockSyntax } = require("../util/postcss-helper");
+
+@suite("Block Names")
+export class BlockNames extends BEMProcessor {
+
+  @test @only "composes may only be used in a rule set"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource(
+      "foo/bar/biz.css",
+      `.baz { color: red; }`,
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block biz from "./biz.css";
+                    @media(max-width: 200px) { composes: biz.baz; }`;
+
+    return assertError(
+      InvalidBlockSyntax,
+      `The "composes" property may only be used in a rule set. (foo/bar/test-block.css:2:48)`,
+      this.process(filename, inputCSS, {importer: imports.importer()}));
+  }
+
+  @test @only "throws on missing block reference"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource(
+      "foo/bar/biz.css",
+      `.baz { color: red; }`,
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block biz from "./biz.css";
+                    .bar { composes: biz.buz; }`;
+
+    return assertError(
+      InvalidBlockSyntax,
+      `No style "biz.buz" found. (foo/bar/test-block.css:2:28)`,
+      this.process(filename, inputCSS, {importer: imports.importer()}));
+  }
+
+  @test @only "throws when referencing the local block"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource(
+      "foo/bar/biz.css",
+      `.baz { color: red; }`,
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block biz from "./biz.css";
+                    .buz { color: green; }
+                    .bar { composes: .buz; }`;
+
+    return assertError(
+      InvalidBlockSyntax,
+      `Styles from the same Block may not be composed together. (foo/bar/test-block.css:3:28)`,
+      this.process(filename, inputCSS, {importer: imports.importer()}));
+  }
+
+  @test @only "composition not allowed on rule sets with a scope selector"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource(
+      "foo/bar/biz.css",
+      `.baz { color: red; }`,
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block biz from "./biz.css";
+                    :scope[state|awesome] .bar { composes: biz.baz; }`;
+
+    return assertError(
+      InvalidBlockSyntax,
+      `Style composition is not allowed in rule sets with a scope selector. (foo/bar/test-block.css:2:50)`,
+      this.process(filename, inputCSS, {importer: imports.importer()}));
+  }
+
+  @test @only "property conflicts that arise from composition must be resolved"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource(
+      "foo/bar/biz.css",
+      `.baz { color: red; }`,
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block biz from "./biz.css";
+                    .bar { composes: biz.baz; color: green; }`;
+
+    return assertError(
+      InvalidBlockSyntax,
+      `Style composition is not allowed in rule sets with a scope selector. (foo/bar/test-block.css:2:50)`,
+      this.process(filename, inputCSS, {importer: imports.importer()}));
+  }
+
+  @only @test "block names in double quotes fail parse with helpful error"() {
+    let imports = new MockImportRegistry();
+    imports.registerSource(
+      "foo/bar/biz.css",
+      `.baz { color: red; }`,
+    );
+
+    let filename = "foo/bar/test-block.css";
+    let inputCSS = `@block biz from "./biz.css";
+                    .bar[state|color][state|inverse] { composes: biz.baz; }`;
+
+    return this.process(filename, inputCSS, {importer: imports.importer()}).then((result) => {
+      assert.deepEqual(
+        result.css.toString(),
+        `.foo__asdf { color: blue; }\n`,
+      );
+    });
+  }
+}

--- a/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import { suite, test } from "mocha-typescript";
 
 import { assertError } from "../util/assertError";
+import { indented } from "../util/indented";
 import { BEMProcessor } from "../util/BEMProcessor";
 import { MockImportRegistry } from "../util/MockImportRegistry";
 
@@ -116,8 +117,25 @@ export class BlockNames extends BEMProcessor {
 
     return this.process(filename, inputCSS, {importer: imports.importer()}).then((result) => {
       assert.deepEqual(
-        result.css.toString(),
-        `.test-block__bar--color.test-block--inverse { background: blue; }\n`,
+        result.css.toString().trim(),
+        indented`
+          .test-block__bar { }
+          .test-block__bar--active { }
+          .test-block__bar--color.test-block--inverse { background: blue; }
+          /* Source: foo/bar/test-block.css
+           * :scope (.test-block)
+           *  composes:
+           *  └── biz
+           *  └── .bar (.test-block__bar)
+           *       composes:
+           *       ├── biz.baz
+           *       ├── biz.buz when [state|active]
+           *       └── biz.baz when [state|color] && [state|inverse]
+           *       states:
+           *       ├── .bar[state|active] (.test-block__bar--active)
+           *       ├── .bar[state|color] (.test-block__bar--color)
+           *       └── .bar[state|inverse] (.test-block__bar--inverse)
+           */`,
       );
     });
   }

--- a/packages/@css-blocks/core/test/BlockParser/block-name-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/block-name-test.ts
@@ -3,8 +3,8 @@ import { skip, suite, test } from "mocha-typescript";
 
 import { assertError } from "../util/assertError";
 import { BEMProcessor } from "../util/BEMProcessor";
-import { MockImportRegistry } from "../util/MockImportRegistry";
 import { indented } from "../util/indented";
+import { MockImportRegistry } from "../util/MockImportRegistry";
 
 const { InvalidBlockSyntax } = require("../util/postcss-helper");
 

--- a/packages/@css-blocks/core/test/BlockParser/block-name-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/block-name-test.ts
@@ -4,6 +4,7 @@ import { skip, suite, test } from "mocha-typescript";
 import { assertError } from "../util/assertError";
 import { BEMProcessor } from "../util/BEMProcessor";
 import { MockImportRegistry } from "../util/MockImportRegistry";
+import { indented } from "../util/indented";
 
 const { InvalidBlockSyntax } = require("../util/postcss-helper");
 
@@ -56,10 +57,12 @@ export class BlockNames extends BEMProcessor {
     return this.process(filename, inputCSS, {importer: imports.importer()}).then((result) => {
       imports.assertImported("foo/bar/imported.css");
       assert.deepEqual(
-        result.css.toString(),
-        `/* Source: foo/bar/imported.css\n` +
-        "   :scope => .imported\n" +
-        "   .not-root => .imported__not-root */\n",
+        result.css.toString().trim(),
+        indented`
+          /* Source: foo/bar/imported.css
+           * :scope (.imported)
+           *  └── .not-root (.imported__not-root)
+           */`,
       );
     });
   }

--- a/packages/@css-blocks/core/test/BlockParser/import-export-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/import-export-test.ts
@@ -3,8 +3,8 @@ import { suite, test } from "mocha-typescript";
 
 import { assertError } from "../util/assertError";
 import { BEMProcessor } from "../util/BEMProcessor";
-import { MockImportRegistry } from "../util/MockImportRegistry";
 import { indented } from "../util/indented";
+import { MockImportRegistry } from "../util/MockImportRegistry";
 
 const { InvalidBlockSyntax } = require("../util/postcss-helper");
 
@@ -44,7 +44,7 @@ export class BlockImportExport extends BEMProcessor {
            *       └── .foo[state|small] (.imported__foo--small)
            */
           .test-block { color: red; }
-          .test-block__b--big { color: blue; }`
+          .test-block__b--big { color: blue; }`,
       );
     });
   }
@@ -268,7 +268,7 @@ export class BlockImportExport extends BEMProcessor {
       indented`
        /* Source: a.css
         * :scope (.block-a)
-        */`,    );
+        */`);
   }
 
   @test async "able to export multiple blocks under external alias of different name"() {

--- a/packages/@css-blocks/core/test/BlockParser/import-export-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/import-export-test.ts
@@ -4,6 +4,7 @@ import { suite, test } from "mocha-typescript";
 import { assertError } from "../util/assertError";
 import { BEMProcessor } from "../util/BEMProcessor";
 import { MockImportRegistry } from "../util/MockImportRegistry";
+import { indented } from "../util/indented";
 
 const { InvalidBlockSyntax } = require("../util/postcss-helper");
 
@@ -30,16 +31,20 @@ export class BlockImportExport extends BEMProcessor {
     return this.process(filename, inputCSS, {importer: imports.importer()}).then((result) => {
       imports.assertImported("foo/bar/imported.css");
       assert.deepEqual(
-        result.css.toString(),
-        `/* Source: foo/bar/imported.css\n` +
-        "   :scope => .imported\n" +
-        "   .foo => .imported__foo\n" +
-        "   .foo[state|font=fancy] => .imported__foo--font-fancy\n" +
-        "   .foo[state|small] => .imported__foo--small\n" +
-        "   :scope[state|large] => .imported--large\n" +
-        "   :scope[state|theme=red] => .imported--theme-red */\n" +
-        ".test-block { color: red; }\n" +
-        ".test-block__b--big { color: blue; }\n",
+        result.css.toString().trim(),
+        indented`
+          /* Source: foo/bar/imported.css
+           * :scope (.imported)
+           *  states:
+           *  ├── :scope[state|large] (.imported--large)
+           *  └── :scope[state|theme=red] (.imported--theme-red)
+           *  └── .foo (.imported__foo)
+           *       states:
+           *       ├── .foo[state|font=fancy] (.imported__foo--font-fancy)
+           *       └── .foo[state|small] (.imported__foo--small)
+           */
+          .test-block { color: red; }
+          .test-block__b--big { color: blue; }`
       );
     });
   }
@@ -58,8 +63,11 @@ export class BlockImportExport extends BEMProcessor {
     return this.process(filename, inputCSS, {importer: imports.importer()}).then((result) => {
       imports.assertImported("foo/bar/imported.css");
       assert.deepEqual(
-        result.css.toString(),
-        `/* Source: foo/bar/imported.css\n   :scope => .phoebe */\n`,
+        result.css.toString().trim(),
+        indented`
+          /* Source: foo/bar/imported.css
+           * :scope (.phoebe)
+           */`,
       );
     });
   }
@@ -78,9 +86,11 @@ export class BlockImportExport extends BEMProcessor {
     return this.process(filename, inputCSS, {importer: imports.importer()}).then((result) => {
       imports.assertImported("foo/bar/imported.css");
       assert.deepEqual(
-        result.css.toString(),
-        `/* Source: foo/bar/imported.css\n` +
-        "   :scope => .snow-flake */\n",
+        result.css.toString().trim(),
+        indented`
+          /* Source: foo/bar/imported.css
+           * :scope (.snow-flake)
+           */`,
       );
     });
   }
@@ -172,9 +182,12 @@ export class BlockImportExport extends BEMProcessor {
     let inputCSS = `@block ( a ) from "./imported.css";
                     @block-debug a to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
-    return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n`,
+    return assert.deepEqual(
+      result.css.trim(),
+      indented`
+      /* Source: a.css
+       * :scope (.block-a)
+       */`,
     );
   }
 
@@ -196,9 +209,12 @@ export class BlockImportExport extends BEMProcessor {
     let inputCSS = `@block ( a ) from "./imported.css";
                     @block-debug a to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
-    return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n`,
+    return assert.deepEqual(
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */`,
     );
   }
 
@@ -220,9 +236,12 @@ export class BlockImportExport extends BEMProcessor {
     let inputCSS = `@block ( foo ) from "./imported.css";
                     @block-debug foo to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
-    return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n`,
+    return assert.deepEqual(
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */`,
     );
   }
 
@@ -244,10 +263,12 @@ export class BlockImportExport extends BEMProcessor {
     let inputCSS = `@block ( bar ) from "./imported.css";
                     @block-debug bar to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
-    return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n`,
-    );
+    return assert.deepEqual(
+      result.css.trim(),
+      indented`
+       /* Source: a.css
+        * :scope (.block-a)
+        */`,    );
   }
 
   @test async "able to export multiple blocks under external alias of different name"() {
@@ -274,10 +295,15 @@ export class BlockImportExport extends BEMProcessor {
                     @block-debug foo to comment;
                     @block-debug bar to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
-    return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n` +
-      `/* Source: b.css\n   :scope => .block-b */\n`,
+    return assert.deepEqual(
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */
+        /* Source: b.css
+         * :scope (.block-b)
+         */`,
     );
   }
   @test async "able to export without parens"() {
@@ -305,9 +331,14 @@ export class BlockImportExport extends BEMProcessor {
                     @block-debug bar to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
     return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n` +
-      `/* Source: b.css\n   :scope => .block-b */\n`,
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */
+        /* Source: b.css
+         * :scope (.block-b)
+         */`,
     );
   }
 
@@ -336,9 +367,14 @@ export class BlockImportExport extends BEMProcessor {
                     @block-debug bar to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
     return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n` +
-      `/* Source: b.css\n   :scope => .block-b */\n`,
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */
+        /* Source: b.css
+         * :scope (.block-b)
+         */`,
     );
   }
 
@@ -369,9 +405,14 @@ export class BlockImportExport extends BEMProcessor {
                     @block-debug bar to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
     return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n` +
-      `/* Source: b.css\n   :scope => .block-b */\n`,
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */
+        /* Source: b.css
+         * :scope (.block-b)
+         */`,
     );
   }
 
@@ -408,10 +449,17 @@ export class BlockImportExport extends BEMProcessor {
                     @block-debug baz to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
     return assert.equal(
-      result.css,
-      `/* Source: a.css\n   :scope => .block-a */\n` +
-      `/* Source: b.css\n   :scope => .block-b */\n` +
-      `/* Source: c.css\n   :scope => .block-c */\n`,
+      result.css.trim(),
+      indented`
+        /* Source: a.css
+         * :scope (.block-a)
+         */
+        /* Source: b.css
+         * :scope (.block-b)
+         */
+        /* Source: c.css
+         * :scope (.block-c)
+         */`,
     );
   }
 
@@ -447,11 +495,20 @@ export class BlockImportExport extends BEMProcessor {
                     @block-debug baz to comment;`;
     let result = await this.process("test.css", inputCSS, {importer: imports.importer()});
     return assert.equal(
-      result.css,
-      `/* Source: imported.css\n   :scope => .imported-block */\n` +
-      `/* Source: a.css\n   :scope => .block-a */\n` +
-      `/* Source: b.css\n   :scope => .block-b */\n` +
-      `/* Source: c.css\n   :scope => .block-c */\n`,
+      result.css.trim(),
+      indented`
+        /* Source: imported.css
+         * :scope (.imported-block)
+         */
+        /* Source: a.css
+         * :scope (.block-a)
+         */
+        /* Source: b.css
+         * :scope (.block-b)
+         */
+        /* Source: c.css
+         * :scope (.block-c)
+         */`,
     );
   }
 

--- a/packages/@css-blocks/core/test/block-inheritance-test.ts
+++ b/packages/@css-blocks/core/test/block-inheritance-test.ts
@@ -4,6 +4,7 @@ import { skip, suite, test } from "mocha-typescript";
 
 import { BEMProcessor } from "./util/BEMProcessor";
 import { setupImporting } from "./util/setupImporting";
+import { indented } from "./util/indented";
 
 @suite("Block Inheritance")
 export class BlockInheritance extends BEMProcessor {
@@ -27,18 +28,23 @@ export class BlockInheritance extends BEMProcessor {
     return this.process(filename, inputCSS, config).then((result) => {
       imports.assertImported("foo/bar/base.css");
       assert.deepEqual(
-        result.css.toString(),
-        ".inherits { color: red; }\n" +
-        ".base.inherits { color: red; }\n" +
-        ".inherits__foo { clear: both; }\n" +
-        ".inherits__b--small { color: blue; }\n" +
-        "/* Source: foo/bar/inherits.css\n" +
-        "   :scope => .base .inherits\n" +
-        "   .b => .inherits__b\n" +
-        "   .b[state|small] => .inherits__b--small\n" +
-        "   .foo => .base__foo .inherits__foo\n" +
-        "   .foo[state|small] => .base__foo--small\n" +
-        "   :scope[state|large] => .base--large */\n",
+        result.css.toString().trim(),
+        indented`
+          .inherits { color: red; }
+          .base.inherits { color: red; }
+          .inherits__foo { clear: both; }
+          .inherits__b--small { color: blue; }
+          /* Source: foo/bar/inherits.css
+           * :scope (.base.inherits)
+           *  states:
+           *  └── :scope[state|large] (.base--large)
+           *  ├── .b (.inherits__b)
+           *  |    states:
+           *  |    └── .b[state|small] (.inherits__b--small)
+           *  └── .foo (.base__foo.inherits__foo)
+           *       states:
+           *       └── .foo[state|small] (.base__foo--small)
+           */`,
       );
     });
   }

--- a/packages/@css-blocks/core/test/block-inheritance-test.ts
+++ b/packages/@css-blocks/core/test/block-inheritance-test.ts
@@ -3,8 +3,8 @@ import { assert } from "chai";
 import { skip, suite, test } from "mocha-typescript";
 
 import { BEMProcessor } from "./util/BEMProcessor";
-import { setupImporting } from "./util/setupImporting";
 import { indented } from "./util/indented";
+import { setupImporting } from "./util/setupImporting";
 
 @suite("Block Inheritance")
 export class BlockInheritance extends BEMProcessor {
@@ -53,7 +53,7 @@ export class BlockInheritance extends BEMProcessor {
   @test "can unset an inherited property"() {
     let { imports, config } = setupImporting();
     // This is hard because the base block and the sub block have to be compiled together to make it work.
-    // or the base block would need to discover all subblocks somehow.
+    // or the base block would need to discover all sub-blocks somehow.
     imports.registerSource(
       "foo/bar/base.css",
       `:scope { color: purple; }

--- a/packages/@css-blocks/core/test/template-analysis-test.ts
+++ b/packages/@css-blocks/core/test/template-analysis-test.ts
@@ -645,7 +645,7 @@ export class AnalysisTests {
     `;
     return assertParseError(
       cssBlocks.TemplateAnalysisError,
-      "Cannot put block classes on the block's root element (templates/my-template.hbs:10:32)",
+      `Cannot put Block classes on the Block's root element. (templates/my-template.hbs:10:32)`,
       this.parseBlock(css, "blocks/foo.block.css", config).then(([block, _]): [Block, postcss.Container] => {
           analysis.addBlock("", block);
           let element = analysis.startElement({ line: 10, column: 32 });

--- a/packages/@css-blocks/core/test/validations/property-conflict-validator-test.ts
+++ b/packages/@css-blocks/core/test/validations/property-conflict-validator-test.ts
@@ -63,7 +63,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a (blocks/foo.block.css:3:37)
@@ -114,7 +114,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a (blocks/foo.block.css:3:37)
@@ -148,7 +148,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.klass (blocks/foo.block.css:4:16)
@@ -199,7 +199,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
 
-      `The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+      `The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
   color:
     block-a (blocks/foo.block.css:3:37)
@@ -261,7 +261,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.bar (blocks/foo.block.css:4:15)
@@ -323,7 +323,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.foo (blocks/foo.block.css:4:15)
@@ -416,7 +416,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.foo (blocks/foo.block.css:4:15)
@@ -476,7 +476,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.foo (blocks/foo.block.css:4:15)
@@ -558,7 +558,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-b (blocks/b.block.css:1:31)
@@ -622,7 +622,7 @@ export class TemplateAnalysisTests {
       TemplateAnalysisError,
 
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.klass[state|foo] (blocks/foo.block.css:5:27)
@@ -675,7 +675,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a[state|foo] (blocks/foo.block.css:4:27)
@@ -738,7 +738,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-b (blocks/b.block.css:2:37)
@@ -799,7 +799,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-b (blocks/b.block.css:2:37)
@@ -844,7 +844,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-b (blocks/b.block.css:1:31)
@@ -991,7 +991,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           color:
             block-a.klass (blocks/foo.block.css:5:16)
@@ -1022,7 +1022,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           background-color:
             analysis.klass (blocks/foo.block.css:3:16)
@@ -1057,7 +1057,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
 
-      `The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+      `The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
   border-color:
     analysis.klass (blocks/foo.block.css:3:16)
@@ -1088,7 +1088,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           background-color:
             analysis.klass (blocks/foo.block.css:3:16)
@@ -1123,7 +1123,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           border-left-color:
             analysis.klass (blocks/foo.block.css:3:43)
@@ -1181,7 +1181,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           border-color:
             a-block.klass (blocks/foo.block.css:4:16)
@@ -1213,7 +1213,7 @@ export class TemplateAnalysisTests {
     return assertParseError(
       TemplateAnalysisError,
       indented`
-        The following property conflicts must be resolved for these co-located Styles: (templates/my-template.hbs:10:32)
+        The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
 
           custom-prop:
             block-a.klass (blocks/foo.block.css:4:16)
@@ -1248,6 +1248,35 @@ export class TemplateAnalysisTests {
       }).then(() => {
         assert.deepEqual(1, 1);
       });
+  }
+
+  // TODO: This check should not happen during Template Validation and can be moved to
+  //       the Block Construction phase when logic is more abstracted.
+  @test "property conflicts that arise from in-stylesheet composition must be resolved"() {
+    let imports = new MockImportRegistry();
+    let options = { importer: imports.importer() };
+    imports.registerSource(
+      "blocks/biz.block.css",
+      `.baz { color: red; }`,
+    );
+
+    let css = `@block biz from "./biz.block.css";
+               .bar { composes: biz.baz; color: green; }`;
+
+    return assertParseError(
+    TemplateAnalysisError,
+    indented`
+      The following property conflicts must be resolved for these composed Styles: (templates/my-template.hbs:10:32)
+
+        color:
+          analysis.bar (blocks/foo.block.css:2:42)
+          biz.baz (blocks/biz.block.css:1:8)`,
+
+      this.parseBlock(css, "blocks/foo.block.css", options).then(([block, _]) => {
+        constructElement(block, ".bar").end();
+        assert.deepEqual(1, 1);
+      }),
+    );
   }
 
 }

--- a/packages/@css-blocks/core/test/validations/property-conflict-validator-test.ts
+++ b/packages/@css-blocks/core/test/validations/property-conflict-validator-test.ts
@@ -1272,7 +1272,7 @@ export class TemplateAnalysisTests {
           analysis.bar (blocks/foo.block.css:2:42)
           biz.baz (blocks/biz.block.css:1:8)`,
 
-      this.parseBlock(css, "blocks/foo.block.css", options).then(([block, _]) => {
+    this.parseBlock(css, "blocks/foo.block.css", options).then(([block, _]) => {
         constructElement(block, ".bar").end();
         assert.deepEqual(1, 1);
       }),

--- a/packages/@css-blocks/core/test/validations/root-class-validator-test.ts
+++ b/packages/@css-blocks/core/test/validations/root-class-validator-test.ts
@@ -42,7 +42,7 @@ export class AnalysisTests {
     `;
     return assertParseError(
       cssBlocks.TemplateAnalysisError,
-      "Cannot put block classes on the block's root element (templates/my-template.hbs:10:32)",
+      "Cannot put Block classes on the Block's root element. (templates/my-template.hbs:10:32)",
       this.parseBlock(css, "blocks/foo.block.css", options).then(([block, _]): [Block, postcss.Container] => {
         analysis.addBlock("", block);
         let element = analysis.startElement({ line: 10, column: 32 });

--- a/packages/@css-blocks/ember-cli/package.json
+++ b/packages/@css-blocks/ember-cli/package.json
@@ -28,7 +28,7 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.2",
     "debug": "^3.1.0",
-    "ember-cli-babel": "^6.16.0",
+    "ember-cli-babel": "7.5.0",
     "ember-cli-htmlbars": "^3.0.0",
     "fs-extra": "^7.0.0",
     "symlink-or-copy": "^1.2.0"

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/controllers/compositions.js
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/controllers/compositions.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  enabled: false,
+  color: 'unset',
+
+  actions: {
+    toggleEnabled() {
+      this.toggleProperty("enabled");
+    },
+    toggleColor() {
+      this.set('color', this.get('color') === 'unset' ? 'yellow' : 'unset');
+    }
+  }
+});

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/router.js
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
   this.route('app-component');
   this.route('ember-builtins');
   this.route('addon-component');
+  this.route('compositions');
   this.mount('in-repo-engine');
   this.mount('in-repo-lazy-engine');
 });

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/routes/compositions.js
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/routes/compositions.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/styles/compositions.block.css
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/styles/compositions.block.css
@@ -1,0 +1,46 @@
+@block util from "./utility.block.css";
+@block inherited from "./inherited-compositions.block.css";
+
+:scope {
+  extends: inherited;
+}
+
+.red {
+  composes: "util.red";
+}
+
+.green {
+  composes: "util.green";
+}
+
+.green-bold {
+  composes: "util.green", "util.bold";
+}
+
+.pink {
+  composes: "util[state|pink]";
+}
+
+.purple {
+  composes: "util[state|purple]";
+}
+
+.blue[state|active] {
+  composes: "util[state|blue]";
+}
+
+.orange[state|active] {
+  composes: "util.orange";
+}
+
+.yellow[state|color="none"] { }
+
+.yellow[state|color="yellow"] {
+  composes: "util[state|yellow]";
+}
+
+.brown[state|color="none"] { }
+
+.brown[state|color="yellow"] {
+  composes: "util.brown";
+}

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/styles/inherited-compositions.block.css
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/styles/inherited-compositions.block.css
@@ -1,0 +1,5 @@
+@block util from "./utility.block.css";
+
+.red {
+  composes: "util.bold";
+}

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/styles/utility.block.css
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/styles/utility.block.css
@@ -1,0 +1,39 @@
+:scope {
+  font-style: italic;
+}
+
+:scope[state|pink] {
+  color: pink;
+}
+
+:scope[state|purple] {
+  color: purple;
+}
+
+.red {
+  color: red;
+}
+
+.green {
+  color: green;
+}
+
+.orange {
+  color: orange;
+}
+
+:scope[state|blue] {
+  color: blue;
+}
+
+:scope[state|yellow] {
+  color: yellow;
+}
+
+.brown {
+  color: brown;
+}
+
+.bold {
+  font-weight: bold;
+}

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/templates/application.hbs
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/templates/application.hbs
@@ -24,6 +24,9 @@
       <li>
         {{#link-to "in-repo-lazy-engine" class="test-nav-item"}}In Repo Lazy Engine{{/link-to}}
       </li>
+      <li>
+        {{#link-to "compositions" class="test-nav-item"}}Compositions{{/link-to}}
+      </li>
     </ul>
   </nav>
 

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/templates/compositions.hbs
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/templates/compositions.hbs
@@ -1,0 +1,35 @@
+<section>
+  <p id="red-static" class="red">I'm red from a static class composition and bold from an inherited composition.</p>
+  <p id="green-static" class="green">I'm green from a static class composition.</p>
+
+  <p id="red-green-dynamic" class={{style-if enabled "green" "red"}}>I'm {{if enabled "green" "red"}} from a dynamic class composition.</p>
+
+  <p id="pink-static" class="pink">I'm pink from a static attribute composition and italic from the composition's parent class.</p>
+  <p id="purple-static" class="purple">I'm purple from a static attribute composition and italic from the composition's parent class.</p>
+
+  <p id="pink-purple-dynamic" class={{style-if enabled "pink" "purple"}}>I'm {{if enabled "pink" "purple"}} from a dynamic attribute composition and italic from the composition's parent class.</p>
+
+  <p id="blue-static" class="blue">I'm not blue from an attribute composition with boolean attribute condition.</p>
+  <p id="blue-active" class="blue" state:active>I'm blue from an attribute composition with boolean attribute condition.</p>
+  <p id="blue-dynamic" class="blue" state:active={{enabled}} >I'm toggled blue from an state composition with boolean attribute condition.</p>
+
+  <p id="orange-static" class="orange">I'm not orange from a class composition with boolean attribute condition.</p>
+  <p id="orange-active" class="orange" state:active>I'm orange from a class composition with boolean attribute condition.</p>
+  <p id="orange-dynamic" class="orange" state:active={{enabled}} >I'm toggled orange from a class with boolean attribute condition.</p>
+
+  <p id="yellow-static" class="yellow" state:color="none">I'm not yellow from a class composition with a switch class condition.</p>
+  <p id="yellow-active" class="yellow" state:color="yellow">I'm yellow from a class composition with a switch class condition.</p>
+  <p id="yellow-dynamic" class="yellow" state:color={{color}}>I'm toggled {{color}} from a class composition with a switch class condition.</p>
+
+  <p id="brown-static" class="brown" state:color="none">I'm not brown from an attribute composition with a switch attribute condition.</p>
+  <p id="brown-active" class="brown" state:color="yellow">I'm brown from an attribute composition with a switch attribute condition.</p>
+  <p id="brown-dynamic" class="brown" state:color={{color}}>I'm toggled brown from an state composition with a switch attribute condition.</p>
+
+  <p id="yellow-brown-dynamic" class={{style-if enabled "yellow" "brown"}} state:color={{color}}>I'm toggled {{if enabled "yellow" "brown"}} or unset from a dynamic {{if enabled "attribute" "class"}} composition.</p>
+
+  <p id="green-bold" class="green-bold">I'm green and bold from multiple class compositions.</p>
+
+  <button {{action "toggleEnabled"}} id="toggle-enabled">Toggle Enabled States</button>
+  <button {{action "toggleColor"}} id="toggle-color">Toggle Color States</button>
+
+</section>

--- a/packages/@css-blocks/ember-cli/tests/integration/template-discovery-test.js
+++ b/packages/@css-blocks/ember-cli/tests/integration/template-discovery-test.js
@@ -5,7 +5,21 @@ function varIsPresent(sel, name) {
   let el = document.querySelector(`#test-container ${sel}`);
   return window.getComputedStyle(el).getPropertyValue(`--${name}`).trim() === "applied";
 }
-function varIsNotPresent(sel, name) { return !varIsPresent(sel, name); }
+
+function propApplied(sel, prop, val) {
+  let el = document.querySelector(`#test-container ${sel}`);
+  const d = document.createElement("div");
+  d.style[prop] = val;
+  document.body.appendChild(d);
+  val = window.getComputedStyle(d).getPropertyValue(prop);
+  d.remove();
+  return window.getComputedStyle(el).getPropertyValue(prop).trim() === val;
+}
+
+const colorApplied = (sel, color) => propApplied(sel, "color", color);
+const isBold = (sel) => propApplied(sel, "font-weight", "bold");
+const isItalic = (sel) => propApplied(sel, "font-style", "italic");
+const varIsNotPresent = (sel, name) => !varIsPresent(sel, name);
 
 module("Acceptance | Template Discovery", function(hooks) {
   setupApplicationTest(hooks);
@@ -77,5 +91,105 @@ module("Acceptance | Template Discovery", function(hooks) {
     await visit("/in-repo-lazy-engine");
     assert.equal(currentURL(), "/in-repo-lazy-engine", "Navigated to test case");
     assert.ok(varIsPresent("#scope", "in-repo-lazy-engine-scope"), "Scope style applied to root element");
+  });
+
+  test("Static and Dynamic In Stylesheet Class Composition.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#red-static", "red"), "Static class compositions work.");
+    assert.ok(isBold("#red-static"), "Inherited compositions are applied.");
+    assert.ok(colorApplied("#green-static", "green"), "Static class compositions work.");
+    assert.ok(colorApplied("#red-green-dynamic", "red"), "Dynamic class compositions work.");
+    assert.ok(isBold("#red-green-dynamic"), "Inherited compositions are applied.");
+    await click("#toggle-enabled");
+    assert.ok(colorApplied("#red-green-dynamic", "green"), "Dynamic class compositions work when changed.");
+    assert.ok(!isBold("#red-green-dynamic"), "Inherited compositions are removed.");
+    await click("#toggle-enabled");
+  });
+
+  test("Static and Dynamic In Stylesheet State Composition.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#pink-static", "pink"), "Static state compositions work.");
+    assert.ok(isItalic("#pink-static"), "The state's base class is automatically applied.")
+    assert.ok(colorApplied("#purple-static", "purple"), "Static state compositions work.");
+    assert.ok(isItalic("#purple-static"), "The state's base class is automatically applied.")
+    assert.ok(colorApplied("#pink-purple-dynamic", "purple"), "Dynamic state compositions work.");
+    assert.ok(isItalic("#pink-purple-dynamic"), "The state's base class is automatically applied.")
+    await click("#toggle-enabled");
+    assert.ok(colorApplied("#pink-purple-dynamic", "pink"), "Dynamic state compositions work.");
+    assert.ok(isItalic("#pink-purple-dynamic"), "The state's base class is automatically applied.")
+    await click("#toggle-enabled");
+  });
+
+  test("Static and Dynamic In Stylesheet State Composition Gated By Boolean State.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#blue-static", "black"), "Static state compositions work gated by a boolean state.");
+    assert.ok(colorApplied("#blue-active", "blue"), "Static state compositions work gated by a boolean state.");
+    assert.ok(colorApplied("#blue-dynamic", "black"), "Dynamic state compositions work gated by a boolean state – inactive.");
+    await click("#toggle-enabled");
+    assert.ok(colorApplied("#blue-dynamic", "blue"), "Dynamic state compositions work gated by a boolean state – active.");
+    await click("#toggle-enabled");
+  });
+
+  test("Static and Dynamic In Stylesheet Class Composition Gated By Boolean State.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#orange-static", "black"), "Static class compositions work gated by a boolean state.");
+    assert.ok(colorApplied("#orange-active", "orange"), "Static class compositions work gated by a boolean state.");
+    assert.ok(colorApplied("#orange-dynamic", "black"), "Dynamic class compositions work gated by a boolean state – inactive.");
+    await click("#toggle-enabled");
+    assert.ok(colorApplied("#orange-dynamic", "orange"), "Dynamic class compositions work gated by a boolean state – active.");
+    await click("#toggle-enabled");
+
+  });
+
+  test("Static and Dynamic In Stylesheet State Composition Gated By Switch State.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#yellow-static", "black"), "Static state compositions work gated by a switch state.");
+    assert.ok(colorApplied("#yellow-active", "yellow"), "Static state compositions work gated by a switch state.");
+    assert.ok(colorApplied("#yellow-dynamic", "black"), "Dynamic state compositions work gated by a switch state – inactive.");
+    await click("#toggle-color");
+    assert.ok(colorApplied("#yellow-dynamic", "yellow"), "Dynamic state compositions work gated by a switch state – active.");
+    await click("#toggle-color");
+
+  });
+
+  test("Static and Dynamic In Stylesheet Class Composition Gated By Switch State.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#brown-static", "black"), "Static class compositions work gated by a switch state.");
+    assert.ok(colorApplied("#brown-active", "brown"), "Static class compositions work gated by a switch state.");
+    assert.ok(colorApplied("#brown-dynamic", "black"), "Dynamic class compositions work gated by a switch state – inactive.");
+    await click("#toggle-color");
+    assert.ok(colorApplied("#brown-dynamic", "brown"), "Dynamic class compositions work gated by a switch state – active.");
+    await click("#toggle-color");
+  });
+
+  test("Dynamic In Stylesheet Composition Gated By Dynamic Switch State.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#yellow-brown-dynamic", "black"), "Conditional applications and state switches work well together – 1");
+    await click("#toggle-enabled");
+    assert.ok(colorApplied("#yellow-brown-dynamic", "black"), "Conditional applications and state switches work well together – 2");
+    assert.ok(!isItalic("#yellow-brown-dynamic"), "When attribute gate is not met, composition parent class is not applied.");
+    await click("#toggle-enabled");
+    await click("#toggle-color");
+    assert.ok(colorApplied("#yellow-brown-dynamic", "brown"), "Conditional applications and state switches work well together – 3");
+    await click("#toggle-enabled");
+    assert.ok(colorApplied("#yellow-brown-dynamic", "yellow"), "Conditional applications and state switches work well together – 4");
+    assert.ok(isItalic("#yellow-brown-dynamic"), "When attribute gate is met, composition parent class is applied.");
+    await click("#toggle-color");
+    assert.ok(!isItalic("#yellow-brown-dynamic"), "Composition parent class is removed when class is switched.");
+    assert.ok(colorApplied("#yellow-brown-dynamic", "black"), "Conditional applications and state switches work well together – 5");
+  });
+
+  test("Multiple In Stylesheet Compositions.", async function(assert) {
+    await visit("/compositions");
+    assert.equal(currentURL(), "/compositions", "Navigated to test case");
+    assert.ok(colorApplied("#green-bold", "green"), "Multiple compositional classes applied – color");
+    assert.ok(isBold("#green-bold"), "Multiple compositional classes applied – font-weight");
   });
 });

--- a/packages/@css-blocks/glimmer/src/ClassnamesHelperGenerator.ts
+++ b/packages/@css-blocks/glimmer/src/ClassnamesHelperGenerator.ts
@@ -193,8 +193,10 @@ function constructConditional(stateExpr: Conditional<BooleanAST> & HasAttrValue,
 function constructStateReferences(stateExpr: HasAttrValue, rewrite: IndexedClassRewrite<Style>): AST.Expression[] {
   let expr = new Array<AST.Expression>();
   // TODO: inheritance
-  expr.push(builders.number(1));
-  expr.push(builders.number(unwrap(rewrite.indexOf(stateExpr.value))));
+  expr.push(builders.number(stateExpr.value.size));
+  for (let val of stateExpr.value) {
+    expr.push(builders.number(unwrap(rewrite.indexOf(val))));
+  }
   return expr;
 }
 /*
@@ -213,7 +215,7 @@ function constructStateReferences(stateExpr: HasAttrValue, rewrite: IndexedClass
  *   2: number (s) of source styles set. s >= 1
  *   3..3+s-1: indexes of source styles set
  */
-function constructSwitch(stateExpr: Switch<StringAST> & HasGroup, rewrite: IndexedClassRewrite<Style>): AST.Expression[] {
+function constructSwitch(stateExpr: Switch<StringAST> & HasGroup & HasAttrValue, rewrite: IndexedClassRewrite<Style>): AST.Expression[] {
   let expr = new Array<AST.Expression>();
   let values = Object.keys(stateExpr.group);
   expr.push(builders.number(values.length));
@@ -226,8 +228,18 @@ function constructSwitch(stateExpr: Switch<StringAST> & HasGroup, rewrite: Index
   for (let value of values) {
     let obj = stateExpr.group[value];
     expr.push(builders.string(value));
-    expr.push(builders.number(1));
-    expr.push(builders.number(unwrap(rewrite.indexOf(obj))));
+    // If there are values provided for this conditional, they are meant to be
+    // applied instead of the selected attribute group member.
+    if (stateExpr.value.size) {
+      expr.push(builders.number(stateExpr.value.size));
+      for (let val of stateExpr.value) {
+        expr.push(builders.number(unwrap(rewrite.indexOf(val))));
+      }
+    }
+    else {
+      expr.push(builders.number(1));
+      expr.push(builders.number(unwrap(rewrite.indexOf(obj))));
+    }
   }
   return expr;
 }

--- a/packages/@css-blocks/glimmer/test/stylesheet-analysis-test.ts
+++ b/packages/@css-blocks/glimmer/test/stylesheet-analysis-test.ts
@@ -99,8 +99,8 @@ describe("Stylesheet analysis", function() {
           staticStyles: [ 0, 3 ],
           dynamicClasses: [],
           dynamicAttributes: [
-            { condition: true, value: 1 },
-            { stringExpression: true, group: { bold: 4, italic: 5 } },
+            { condition: true, value: [ 1 ] },
+            { stringExpression: true, group: { bold: 4, italic: 5 }, value: [] },
           ],
           sourceLocation: { start: { line: 2, column: 23, "filename": "template:/styled-app/components/with-dynamic-states" }, end: { line: 2, column: 23, "filename": "template:/styled-app/components/with-dynamic-states" } },
         },
@@ -153,8 +153,8 @@ describe("Stylesheet analysis", function() {
           staticStyles: [ 3, 7 ],
           dynamicClasses: [ {condition: true, whenTrue: [ 0 ]} ],
           dynamicAttributes: [
-            { condition: true, value: 1, container: 0 },
-            { stringExpression: true, group: { bold: 4, italic: 5 } },
+            { condition: true, value: [ 1 ], container: 0 },
+            { stringExpression: true, group: { bold: 4, italic: 5 }, value: [] },
           ],
           sourceLocation: { start: { line: 2, column: 23, "filename": "template:/styled-app/components/with-dynamic-classes" }, end: { line: 2, column: 23, "filename": "template:/styled-app/components/with-dynamic-classes" } },
         },

--- a/packages/@css-blocks/jsx/src/transformer/classNameGenerator.ts
+++ b/packages/@css-blocks/jsx/src/transformer/classNameGenerator.ts
@@ -191,8 +191,10 @@ function constructConditional(attr: Conditional<BooleanAST> & HasAttrValue, _rew
 function constructAttrReferences(attr: HasAttrValue, rewrite: IndexedClassRewrite<Style>): Array<Expression> {
   let expr = new Array<Expression>();
   // TODO: inheritance
-  expr.push(builders.number(1));
-  expr.push(builders.number(unwrap(rewrite.indexOf(attr.value))));
+  expr.push(builders.number(attr.value.size));
+  for (let val of attr.value) {
+    expr.push(builders.number(unwrap(rewrite.indexOf(val))));
+  }
   return expr;
 }
 /*
@@ -211,7 +213,7 @@ function constructAttrReferences(attr: HasAttrValue, rewrite: IndexedClassRewrit
  *   2: number (s) of source styles set. s >= 1
  *   3..3+s-1: indexes of source styles set
  */
-function constructSwitch(attr: Switch<StringAST> & HasGroup, rewrite: IndexedClassRewrite<Style>): Array<Expression> {
+function constructSwitch(attr: Switch<StringAST> & HasGroup & HasAttrValue, rewrite: IndexedClassRewrite<Style>): Array<Expression> {
   let expr = new Array<Expression>();
   let values = Object.keys(attr.group);
   expr.push(builders.number(values.length));
@@ -224,8 +226,16 @@ function constructSwitch(attr: Switch<StringAST> & HasGroup, rewrite: IndexedCla
   for (let value of values) {
     let obj = attr.group[value];
     expr.push(builders.string(value));
-    expr.push(builders.number(1));
-    expr.push(builders.number(unwrap(rewrite.indexOf(obj))));
+    if (attr.value.size) {
+      expr.push(builders.number(attr.value.size));
+      for (let val of attr.value) {
+        expr.push(builders.number(unwrap(rewrite.indexOf(val))));
+      }
+    }
+    else {
+      expr.push(builders.number(1));
+      expr.push(builders.number(unwrap(rewrite.indexOf(obj))));
+    }
   }
   return expr;
 }

--- a/packages/@css-blocks/jsx/test/analyzer/class-states-objstr-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/class-states-objstr-test.ts
@@ -73,7 +73,7 @@ export class Test {
       let analysis = result.analyses[0];
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(elementAnalysis.dynamicClasses, []);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: 1}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: [ 1 ]}]);
       assert.deepEqual(elementAnalysis.staticStyles, [0]);
       assert.deepEqual(analysis.stylesFound, ["bar.pretty", "bar.pretty[state|color=yellow]"]);
     });
@@ -195,7 +195,7 @@ export class Test {
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(analysis.stylesFound, ["bar.pretty", "bar.pretty[state|color=black]", "bar.pretty[state|color=green]", "bar.pretty[state|color=yellow]"]);
       assert.deepEqual(elementAnalysis.dynamicClasses, []);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{stringExpression: true, group: {black: 1, green: 2, yellow: 3}}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{ stringExpression: true, group: {black: 1, green: 2, yellow: 3}, value: [] }]);
       assert.deepEqual(elementAnalysis.staticStyles, [0]);
     });
   }
@@ -267,7 +267,7 @@ export class Test {
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(analysis.stylesFound, ["bar.pretty", "bar.pretty[state|awesome]"]);
       assert.deepEqual(elementAnalysis.dynamicClasses, []);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: 1}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: [ 1 ]}]);
       assert.deepEqual(elementAnalysis.staticStyles, [0]);
     });
   }

--- a/packages/@css-blocks/jsx/test/analyzer/inline-objstr-styles-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/inline-objstr-styles-test.ts
@@ -54,7 +54,7 @@ export class Test {
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(analysis.stylesFound, ["bar.foo", "bar.foo[state|always]"]);
       assert.deepEqual(elementAnalysis.dynamicClasses, []);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: 1}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: [ 1 ]}]);
       assert.deepEqual(elementAnalysis.staticStyles, [0]);
     });
   }

--- a/packages/@css-blocks/jsx/test/analyzer/root-states-objstr-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/root-states-objstr-test.ts
@@ -71,7 +71,7 @@ export class Test {
       let analysis = result.analyses[0];
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(elementAnalysis.dynamicClasses, []);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: 1}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: [ 1 ]}]);
       assert.deepEqual(elementAnalysis.staticStyles, [0]);
       assert.deepEqual(analysis.stylesFound, ["bar:scope", "bar:scope[state|color=yellow]"]);
     });
@@ -102,7 +102,7 @@ export class Test {
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(analysis.stylesFound, ["bar:scope", "bar:scope[state|awesome]"]);
       assert.deepEqual(elementAnalysis.dynamicClasses, [{condition: true, whenTrue: [0]}]);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{container: 0, value: 1}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{container: 0, value: [ 1 ]}]);
       assert.deepEqual(elementAnalysis.staticStyles, []);
     });
   }
@@ -132,7 +132,7 @@ export class Test {
       let elementAnalysis = analysis.elements.a;
       assert.deepEqual(analysis.stylesFound, ["bar:scope", "bar:scope[state|awesome]"]);
       assert.deepEqual(elementAnalysis.dynamicClasses, []);
-      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: 1}]);
+      assert.deepEqual(elementAnalysis.dynamicAttributes, [{condition: true, value: [ 1 ]}]);
       assert.deepEqual(elementAnalysis.staticStyles, [0]);
     });
   }

--- a/packages/@css-blocks/runtime/package.json
+++ b/packages/@css-blocks/runtime/package.json
@@ -2,15 +2,16 @@
   "name": "@css-blocks/runtime",
   "version": "0.20.0",
   "description": "Browser runtime for computing dynamic classnames with css-blocks.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "pretest": "yarn run compile",
     "posttest": "yarn run lint",
-    "test": "echo 'tested in @css-blocks/jsx'",
+    "test": "mocha dist/test --opts test/mocha.opts",
+    "watch": "watch 'yarn run test' './src' './test' --wait=1",
     "compile": "rm -rf dist && tsc",
     "prepublish": "yarn run compile && yarn run lintall",
     "lint": "tslint -t msbuild -c tslint.cli.json --project .",

--- a/packages/@css-blocks/runtime/test/expression-test.ts
+++ b/packages/@css-blocks/runtime/test/expression-test.ts
@@ -1,0 +1,9 @@
+import { assert } from "chai";
+import { suite, test } from "mocha-typescript";
+
+@suite("Expression")
+export class ExpressionTests {
+  @test "runs"() {
+    assert.equal(1, 1);
+  }
+}

--- a/packages/@css-blocks/runtime/test/mocha.opts
+++ b/packages/@css-blocks/runtime/test/mocha.opts
@@ -1,0 +1,4 @@
+--reporter spec
+--require source-map-support/register
+--inline-diffs
+--recursive

--- a/packages/@css-blocks/runtime/tsconfig.json
+++ b/packages/@css-blocks/runtime/tsconfig.json
@@ -11,7 +11,7 @@
     "removeComments": true,
 
     // Environment Configuration
-    "experimentalDecorators": false,
+    "experimentalDecorators": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
 
@@ -34,6 +34,7 @@
     "outDir": "dist"
   },
   "include": [
-    "src/*.ts"
+    "src",
+    "test"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,552 @@
     debug "^3.1.0"
     simple-html-tokenizer "^0.5.1"
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.0.0", "@babel/core@^7.3.3":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz#921a5a13746c21e32445bf0798680e9d11a6530b"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.3.4"
+    "@babel/helpers" "^7.2.0"
+    "@babel/parser" "^7.3.4"
+    "@babel/template" "^7.2.2"
+    "@babel/traverse" "^7.3.4"
+    "@babel/types" "^7.3.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz#9aa48c1989257877a9d971296e5b73bfe72e446e"
+  dependencies:
+    "@babel/types" "^7.3.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f"
+  dependencies:
+    "@babel/helper-explode-assignable-expression" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-call-delegate@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz#6a957f105f37755e8645343d3038a22e1449cc4a"
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-define-map@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/helper-explode-assignable-expression@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6"
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-hoist-variables@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz#46adc4c5e758645ae7a45deb92bab0918c23bb88"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-member-expression-to-functions@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-transforms@^7.1.0":
+  version "7.2.2"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz#ab2f8e8d231409f8370c883d20c335190284b963"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/template" "^7.2.2"
+    "@babel/types" "^7.2.2"
+    lodash "^4.17.10"
+
+"@babel/helper-optimise-call-expression@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-plugin-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+
+"@babel/helper-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
+  dependencies:
+    lodash "^4.17.10"
+
+"@babel/helper-remap-async-to-generator@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-wrap-function" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-replace-supers@^7.1.0", "@babel/helper-replace-supers@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz#a795208e9b911a6eeb08e5891faacf06e7013e13"
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.3.4"
+    "@babel/types" "^7.3.4"
+
+"@babel/helper-simple-access@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
+  dependencies:
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-wrap-function@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.2.0"
+
+"@babel/helpers@^7.2.0":
+  version "7.3.1"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz#949eec9ea4b45d3210feb7dc1c22db664c9e44b9"
+  dependencies:
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.5"
+    "@babel/types" "^7.3.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.2.2", "@babel/parser@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
+
+"@babel/plugin-proposal-async-generator-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+
+"@babel/plugin-proposal-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz#47f73cf7f2a721aad5c0261205405c642e424654"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.2.0"
+
+"@babel/plugin-syntax-async-generators@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-object-rest-spread@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-arrow-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-async-to-generator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz#4e45408d3c3da231c0e7b823f407a53a7eb3048c"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+
+"@babel/plugin-transform-block-scoped-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-block-scoping@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz#5c22c339de234076eee96c8783b2fed61202c5c4"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.11"
+
+"@babel/plugin-transform-classes@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz#dc173cb999c6c5297e0b5f2277fdaaec3739d0cc"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.1.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.3.4"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    globals "^11.1.0"
+
+"@babel/plugin-transform-computed-properties@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-destructuring@^7.2.0":
+  version "7.3.2"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz#f2f5520be055ba1c38c41c0e094d8a461dd78f2d"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-dotall-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz#f0aabb93d120a8ac61e925ea0ba440812dbe0e49"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-duplicate-keys@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz#d952c4930f312a4dbfff18f0b2914e60c35530b3"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-exponentiation-operator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz#a63868289e5b4007f7054d46491af51435766008"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-for-of@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz#ab7468befa80f764bb03d3cb5eef8cc998e1cad9"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-function-name@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz#f7930362829ff99a3174c39f0afcc024ef59731a"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-amd@^7.0.0", "@babel/plugin-transform-modules-amd@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz#82a9bce45b95441f617a24011dc89d12da7f4ee6"
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz#c4f1933f5991d5145e9cfad1dfd848ea1727f404"
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz#813b34cd9acb6ba70a84939f3680be0eb2e58861"
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-umd@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz#7678ce75169f0877b8eb2235538c074268dd01ae"
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-named-capturing-groups-regex@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz#140b52985b2d6ef0cb092ef3b29502b990f9cd50"
+  dependencies:
+    regexp-tree "^0.1.0"
+
+"@babel/plugin-transform-new-target@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-object-super@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+
+"@babel/plugin-transform-parameters@^7.2.0":
+  version "7.3.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.3.3.tgz#3a873e07114e1a5bee17d04815662c8317f10e30"
+  dependencies:
+    "@babel/helper-call-delegate" "^7.1.0"
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-regenerator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz#1601655c362f5b38eead6a52631f5106b29fa46a"
+  dependencies:
+    regenerator-transform "^0.13.4"
+
+"@babel/plugin-transform-runtime@^7.2.0":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz#57805ac8c1798d102ecd75c03b024a5b3ea9b431"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-shorthand-properties@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-spread@^7.2.0":
+  version "7.2.2"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-sticky-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz#a1e454b5995560a9c1e0d537dfc15061fd2687e1"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+
+"@babel/plugin-transform-template-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz#d87ed01b8eaac7a92473f608c97c089de2ba1e5b"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-typeof-symbol@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-unicode-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz#4eb8db16f972f8abb5062c161b8b115546ade08b"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.1.3"
+
+"@babel/polyfill@^7.0.0":
+  version "7.2.5"
+  resolved "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz#6c54b964f71ad27edddc567d065e57e87ed7fa7d"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
+"@babel/preset-env@^7.0.0":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz#887cf38b6d23c82f19b5135298bdb160062e33e1"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.3.4"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.2.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.3.4"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.3.4"
+    "@babel/plugin-transform-classes" "^7.3.4"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.2.0"
+    "@babel/plugin-transform-dotall-regex" "^7.2.0"
+    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.2.0"
+    "@babel/plugin-transform-function-name" "^7.2.0"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.2.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.3.4"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.3.0"
+    "@babel/plugin-transform-new-target" "^7.0.0"
+    "@babel/plugin-transform-object-super" "^7.2.0"
+    "@babel/plugin-transform-parameters" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.3.4"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.2.0"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.2.0"
+    browserslist "^4.3.4"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.3.0"
+
+"@babel/runtime@^7.2.0":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.2.2"
+    "@babel/types" "^7.2.2"
+
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz#1330aab72234f8dea091b08c4f8b9d05c7119e06"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.3.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.3.4"
+    "@babel/types" "^7.3.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz#bf482eaeaffb367a28abbf9357a94963235d90ed"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
 "@commitlint/cli@^6.1.0":
   version "6.2.0"
   resolved "https://registry.npmjs.org/@commitlint/cli/-/cli-6.2.0.tgz#b2f8190eb08ccd78eea65114b864f3c65eca466a"
@@ -1159,7 +1705,7 @@
   version "0.3.0"
   resolved "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
 
-"@types/minimatch@*", "@types/minimatch@3.0.3":
+"@types/minimatch@*", "@types/minimatch@3.0.3", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
@@ -1411,6 +1957,13 @@ amd-name-resolver@^0.0.6:
   resolved "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz#d3e4ba2dfcaab1d820c1be9de947c67828cfe595"
   dependencies:
     ensure-posix-path "^1.0.1"
+
+amd-name-resolver@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.3.1.tgz#ffe71c683c6e7191fc4ae1bb3aaed15abea135d9"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+    object-hash "^1.3.1"
 
 amdefine@>=0.0.4, amdefine@^1.0.0:
   version "1.0.1"
@@ -2033,6 +2586,12 @@ babel-plugin-debug-macros@^0.2.0-beta.6:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.0.tgz#7a025944faef0777804ef3518c54e8b040197397"
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-dynamic-import-node@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.1.0.tgz#bd1d88ac7aaf98df4917c384373b04d971a2b37a"
@@ -2046,6 +2605,12 @@ babel-plugin-ember-modules-api-polyfill@^2.3.2:
   resolved "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.2.tgz#56ea34bea963498d070a2b7dc2ce18a92c434093"
   dependencies:
     ember-rfc176-data "^0.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.7.0.tgz#dcd6a9999da0d47d8c9185362bda6244ca525f4a"
+  dependencies:
+    ember-rfc176-data "^0.3.7"
 
 babel-plugin-external-helpers@^6.22.0:
   version "6.22.0"
@@ -2073,6 +2638,16 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+
+babel-plugin-module-resolver@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz#ddfa5e301e3b9aa12d852a9979f18b37881ff5a7"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -2816,6 +3391,22 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.1.2, broccoli-bab
     rsvp "^4.8.2"
     workerpool "^2.3.0"
 
+broccoli-babel-transpiler@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.2.0.tgz#5c0d694c4055106abb385e2d3d88936d35b7cb18"
+  dependencies:
+    "@babel/core" "^7.3.3"
+    "@babel/polyfill" "^7.0.0"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-persistent-filter "^2.2.1"
+    clone "^2.1.2"
+    hash-for-dep "^1.4.7"
+    heimdalljs-logger "^0.1.9"
+    json-stable-stringify "^1.0.1"
+    rsvp "^4.8.4"
+    workerpool "^3.1.1"
+
 broccoli-builder@^0.18.8:
   version "0.18.14"
   resolved "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.14.tgz#4b79e2f844de11a4e1b816c3f49c6df4776c312d"
@@ -3006,6 +3597,24 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
+broccoli-funnel@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz#0edf629569bc10bd02cc525f74b9a38e71366a75"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
 broccoli-kitchen-sink-helpers@^0.2.5:
   version "0.2.9"
   resolved "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
@@ -3111,6 +3720,24 @@ broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-p
     rsvp "^3.0.18"
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
+
+broccoli-persistent-filter@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.2.1.tgz#d2a911ec02ebbbcfb382242c517159cb7a9c10d7"
+  dependencies:
+    async-disk-cache "^1.2.1"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^1.0.0"
+    fs-tree-diff "^1.0.2"
+    hash-for-dep "^1.0.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    mkdirp "^0.5.1"
+    promise-map-series "^0.2.1"
+    rimraf "^2.6.1"
+    rsvp "^4.7.0"
+    symlink-or-copy "^1.0.1"
+    walk-sync "^1.0.0"
 
 broccoli-plugin@1.1.0:
   version "1.1.0"
@@ -3365,6 +3992,14 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
+browserslist@^4.3.4:
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.4.2.tgz#6ea8a74d6464bb0bd549105f659b41197d8f0ba2"
+  dependencies:
+    caniuse-lite "^1.0.30000939"
+    electron-to-chromium "^1.3.113"
+    node-releases "^1.1.8"
+
 bser@1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
@@ -3571,6 +4206,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
 caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000844:
   version "1.0.30000874"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz#a641b1f1c420d58d9b132920ef6ba87bbdcd2223"
+
+caniuse-lite@^1.0.30000939:
+  version "1.0.30000939"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz#b9ab7ac9e861bf78840b80c5dfbc471a5cd7e679"
 
 capture-exit@^1.1.0, capture-exit@^1.2.0:
   version "1.2.0"
@@ -3846,7 +4485,7 @@ clone@^1.0.0, clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
-clone@^2.0.0:
+clone@^2.0.0, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
 
@@ -4205,6 +4844,12 @@ conventional-recommended-bump@^2.0.6:
     meow "^4.0.0"
     q "^1.5.1"
 
+convert-source-map@^1.1.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  dependencies:
+    safe-buffer "~5.1.1"
+
 convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -4247,6 +4892,10 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
+core-js@^2.5.7:
+  version "2.6.5"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
 
 core-js@~2.3.0:
   version "2.3.0"
@@ -4583,7 +5232,7 @@ debug@3.1.0, debug@^3.0.1, debug@^3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4:
+debug@4, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   dependencies:
@@ -4963,6 +5612,10 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@
   version "1.3.57"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.57.tgz#61b2446f16af26fb8873210007a7637ad644c82d"
 
+electron-to-chromium@^1.3.113:
+  version "1.3.113"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
+
 elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
@@ -5011,6 +5664,29 @@ ember-build-utilities@^0.4.0:
     lodash.defaultsdeep "^4.6.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
+
+ember-cli-babel@7.5.0:
+  version "7.5.0"
+  resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.5.0.tgz#af654dcef23630391d2efe85aaa3bdf8b6ca17b7"
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.7.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
 
 ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.16.0"
@@ -5350,6 +6026,10 @@ ember-rfc176-data@^0.3.0, ember-rfc176-data@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.3.tgz#27fba08d540a7463a4366c48eaa19c5a44971a39"
 
+ember-rfc176-data@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.7.tgz#ecff7d74987d09296d3703343fed934515a4be33"
+
 ember-router-generator@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
@@ -5474,6 +6154,10 @@ enhanced-resolve@^3.0.0, enhanced-resolve@^3.4.0:
 ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz#a65b3e42d0b71cfc585eb774f9943c8d9b91b0c2"
+
+ensure-posix-path@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
 
 entities@~1.1.1:
   version "1.1.1"
@@ -6308,6 +6992,13 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
@@ -6572,6 +7263,15 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
 fs-tree-diff@^0.5.9:
   version "0.5.9"
   resolved "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz#a4ec6182c2f5bd80b9b83c8e23e4522e6f5fd946"
+  dependencies:
+    heimdalljs-logger "^0.1.7"
+    object-assign "^4.1.0"
+    path-posix "^1.0.0"
+    symlink-or-copy "^1.1.8"
+
+fs-tree-diff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-1.0.2.tgz#0e2931733a85b55feb3472c0b89a20b0c03ac0de"
   dependencies:
     heimdalljs-logger "^0.1.7"
     object-assign "^4.1.0"
@@ -6870,6 +7570,10 @@ globals@^11.0.1:
   version "11.7.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
+globals@^11.1.0:
+  version "11.11.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -7112,6 +7816,16 @@ hash-for-dep@^1.0.2, hash-for-dep@^1.2.3:
     broccoli-kitchen-sink-helpers "^0.3.1"
     heimdalljs "^0.2.3"
     heimdalljs-logger "^0.1.7"
+    resolve "^1.4.0"
+
+hash-for-dep@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.4.7.tgz#ea6f9d8e2f9e784fc48ca60c40ea886bdb41aa54"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    heimdalljs "^0.2.3"
+    heimdalljs-logger "^0.1.7"
+    path-root "^0.1.1"
     resolve "^1.4.0"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
@@ -8231,6 +8945,10 @@ js-base64@^2.1.9:
   version "2.4.8"
   resolved "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz#57a9b130888f956834aa40c5b165ba59c758f033"
 
+js-levenshtein@^1.1.3:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+
 js-reporters@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.0.tgz#7cf2cb698196684790350d0c4ca07f4aed9ec17e"
@@ -8243,7 +8961,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
@@ -8304,6 +9022,10 @@ jsesc@^2.5.0:
   version "2.5.1"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+
 jsesc@~0.3.x:
   version "0.3.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz#1bf5ee63b4539fe2e26d0c1e99c240b97a457972"
@@ -8353,6 +9075,12 @@ json3@3.3.2, json3@^3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  dependencies:
+    minimist "^1.2.0"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -9055,7 +9783,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4:
+lodash@^4, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -9210,6 +9938,12 @@ marked@^0.3.17, marked@^0.3.19:
 matcher-collection@^1.0.0, matcher-collection@^1.0.4, matcher-collection@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
+  dependencies:
+    minimatch "^3.0.2"
+
+matcher-collection@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz#1076f506f10ca85897b53d14ef54f90a5c426838"
   dependencies:
     minimatch "^3.0.2"
 
@@ -9818,6 +10552,12 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-releases@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.8.tgz#32a63fff63c5e51b7e0f540ac95947d220fc6862"
+  dependencies:
+    semver "^5.3.0"
+
 nomnom@~1.6.2:
   version "1.6.2"
   resolved "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
@@ -9984,6 +10724,10 @@ object-copy@^0.1.0:
 object-hash@^1.1.4:
   version "1.3.0"
   resolved "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
+
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
 
 object-keys@^1.0.8:
   version "1.0.12"
@@ -10418,6 +11162,16 @@ path-posix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
 
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  dependencies:
+    path-root-regex "^0.1.0"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -10504,6 +11258,12 @@ pkg-dir@^1.0.0:
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  dependencies:
+    find-up "^2.1.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
     find-up "^2.1.0"
 
@@ -11482,6 +12242,10 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -11492,6 +12256,12 @@ regenerator-transform@^0.10.0:
   dependencies:
     babel-runtime "^6.18.0"
     babel-types "^6.19.0"
+    private "^0.1.6"
+
+regenerator-transform@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
+  dependencies:
     private "^0.1.6"
 
 regex-cache@^0.4.2:
@@ -11506,6 +12276,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp-tree@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz#7cd71fca17198d04b4176efd79713f2998009397"
 
 regexpp@^1.0.1:
   version "1.1.0"
@@ -11542,6 +12316,17 @@ regexpu-core@^4.0.11:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.0.2"
 
+regexpu-core@^4.1.3, regexpu-core@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz#8d43e0d1266883969720345e70c275ee0aec0d32"
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^7.0.0"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.0.2"
+
 registry-auth-token@^3.0.1:
   version "3.3.2"
   resolved "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
@@ -11563,6 +12348,10 @@ regjsgen@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz#c1eb4c89a209263f8717c782591523913ede2561"
 
+regjsgen@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
+
 regjsparser@^0.1.4:
   version "0.1.5"
   resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
@@ -11572,6 +12361,12 @@ regjsparser@^0.1.4:
 regjsparser@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz#3c326da7fcfd69fa0d332575a41c8c0cdf588c96"
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c"
   dependencies:
     jsesc "~0.5.0"
 
@@ -11680,6 +12475,10 @@ require-uncached@^1.0.3:
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -11831,6 +12630,10 @@ rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0
 rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.2, rsvp@^4.8.3:
   version "4.8.3"
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.3.tgz#25d4b9fdd0f95e216eb5884d9b3767d3fbfbe2cd"
+
+rsvp@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
 
 rsvp@~3.2.1:
   version "3.2.1"
@@ -12535,7 +13338,7 @@ source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
+source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -13791,6 +14594,14 @@ walk-sync@^0.3.3:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
+walk-sync@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.3.tgz#3b7b6468f068b5eba2278c931c57db3d39092969"
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    ensure-posix-path "^1.1.0"
+    matcher-collection "^1.1.1"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -14086,6 +14897,12 @@ worker-farm@^1.3.1:
 workerpool@^2.3.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-2.3.1.tgz#6872d3a749dd820d42b8390abaac20fb14ce4c81"
+  dependencies:
+    object-assign "4.1.1"
+
+workerpool@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-3.1.1.tgz#9decea76b73c2f91de1b5bec1019f8a474b3a620"
   dependencies:
     object-assign "4.1.1"
 


### PR DESCRIPTION
Implements a variation of #72.

## Summary

 - [x] Add `composes` declaration to BlockParser,
 - [x] Validate `composes`  inputs,
 - [x] Track composed styles on the BlockClass,
 - [x] Validate property conflicts between composed Blocks,
 - [x] Output the correct collection of classes on rewrite.

## Detailed Design

Currently, any Block Styles may be composed on an element in-template:

```css
/* foo.block.css */
.bar {
  color: green;
  background: yellow;
}

/* biz.block.css */
@block foo from "./foo.block.css";
.baz { 
  color: red; 
  color: resolve(foo.bar);
}
```
```hbs
{{!-- biz.hbs --}}
<div class="baz foo.bar"></div>
```
However, there are many times where in-template style composition is tedious and repetitive. In use cases where a style author wants to ensure that two Block Styles will always be composed together, we require an in-stylesheet composition feature to permanently associate two styles:

```css
/* foo.block.css */
.bar {
  color: green;
  background: yellow;
}

/* biz.block.css */
@block foo from "./foo.block.css";
.baz { 
  composes: foo.bar;
  color: red; 
  color: resolve(foo.bar);
}
```
```hbs
{{!-- biz.hbs --}}
<div class="baz"></div>
```

Which then builds to the same output as in-template composition:
```hbs
{{!-- biz.hbs --}}
<div class="biz__baz foo__bar"></div>
```
