### PR TITLE
feat(glimmer): {{link-to}} integration.

### DIFF
--- a/packages/@css-blocks/core/src/TemplateRewriter/StyleMapping.ts
+++ b/packages/@css-blocks/core/src/TemplateRewriter/StyleMapping.ts
@@ -13,7 +13,7 @@ export class StyleMapping<T extends keyof TemplateTypes> {
   /** The blocks that were used to create this mapping. */
   blocks: Set<Block>;
   private configuration: ResolvedConfiguration;
-  private optimizedMap: OptimizedMapping;
+  public optimizedMap: OptimizedMapping;
 
   constructor(
     optimizedMap: OptimizedMapping,

--- a/packages/@css-blocks/core/src/TemplateRewriter/StyleMapping.ts
+++ b/packages/@css-blocks/core/src/TemplateRewriter/StyleMapping.ts
@@ -13,7 +13,7 @@ export class StyleMapping<T extends keyof TemplateTypes> {
   /** The blocks that were used to create this mapping. */
   blocks: Set<Block>;
   private configuration: ResolvedConfiguration;
-  public optimizedMap: OptimizedMapping;
+  private optimizedMap: OptimizedMapping;
 
   constructor(
     optimizedMap: OptimizedMapping,

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/styles/ember-builtins.block.css
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/styles/ember-builtins.block.css
@@ -1,9 +1,11 @@
 .link-to-helper {
   --link-to-helper: applied;
+  color: red;
 }
 
 .link-to-helper[state|active] {
   --link-to-helper-active: applied;
+  color: green;
 }
 
 .input-helper {

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/templates/ember-builtins.hbs
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/templates/ember-builtins.hbs
@@ -1,7 +1,4 @@
 <div>
   {{#link-to "index" class="link-to-helper" id="link-to-helper"}}Inactive Link To Helper{{/link-to}}
   {{#link-to "ember-builtins" class="link-to-helper" id="link-to-helper-active"}}Active Link To Helper{{/link-to}}
-
-  {{input type="text" class="input-helper" id="input-helper"}}
-  {{textarea type="text" class="textarea-helper" id="textarea-helper"}}
 </div>

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/templates/ember-builtins.hbs
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/templates/ember-builtins.hbs
@@ -1,5 +1,7 @@
-{{#link-to "index" class="link-to-helper" id="link-to-helper"}}Link To Helper{{/link-to}}
-{{#link-to "ember-builtins" class="link-to-helper" id="link-to-helper-active"}}Active Link To Helper{{/link-to}}
+<div>
+  {{#link-to "index" class="link-to-helper" id="link-to-helper"}}Inactive Link To Helper{{/link-to}}
+  {{#link-to "ember-builtins" class="link-to-helper" id="link-to-helper-active"}}Active Link To Helper{{/link-to}}
 
-{{input type="text" class="input-helper" id="input-helper"}}
-{{textarea type="text" class="textarea-helper" id="textarea-helper"}}
+  {{input type="text" class="input-helper" id="input-helper"}}
+  {{textarea type="text" class="textarea-helper" id="textarea-helper"}}
+</div>

--- a/packages/@css-blocks/ember-cli/tests/integration/template-discovery-test.js
+++ b/packages/@css-blocks/ember-cli/tests/integration/template-discovery-test.js
@@ -16,13 +16,13 @@ module("Acceptance | Template Discovery", function(hooks) {
     assert.ok(varIsPresent("#reset-stylesheet-selector", "reset-stylesheet-selector"), "Vanilla CSS styles in app.css are preserved");
   });
 
-  skip("Ember Builtins Integration", async function(assert) {
+  test("Ember Builtins Integration", async function(assert) {
     await visit("/ember-builtins", "Navigated to test case");
     assert.equal(currentURL(), "/ember-builtins");
     assert.ok(varIsPresent("#link-to-helper", "link-to-helper"), "Link-to helpers receive classes");
     assert.ok(varIsPresent("#link-to-helper-active", "link-to-helper-active"), "Link-to helpers receive active states");
-    assert.ok(varIsPresent("#input-helper", "input-helper"), "Input helpers receive classes");
-    assert.ok(varIsPresent("#textarea-helper", "textarea-helper"), "Textarea helpers receive classes");
+    // assert.ok(varIsPresent("#input-helper", "input-helper"), "Input helpers receive classes");
+    // assert.ok(varIsPresent("#textarea-helper", "textarea-helper"), "Textarea helpers receive classes");
   });
 
   test("App Route Block Integration", async function(assert) {

--- a/packages/@css-blocks/ember-cli/tests/integration/template-discovery-test.js
+++ b/packages/@css-blocks/ember-cli/tests/integration/template-discovery-test.js
@@ -21,8 +21,6 @@ module("Acceptance | Template Discovery", function(hooks) {
     assert.equal(currentURL(), "/ember-builtins");
     assert.ok(varIsPresent("#link-to-helper", "link-to-helper"), "Link-to helpers receive classes");
     assert.ok(varIsPresent("#link-to-helper-active", "link-to-helper-active"), "Link-to helpers receive active states");
-    // assert.ok(varIsPresent("#input-helper", "input-helper"), "Input helpers receive classes");
-    // assert.ok(varIsPresent("#textarea-helper", "textarea-helper"), "Textarea helpers receive classes");
   });
 
   test("App Route Block Integration", async function(assert) {

--- a/packages/@css-blocks/glimmer/src/Analyzer.ts
+++ b/packages/@css-blocks/glimmer/src/Analyzer.ts
@@ -133,7 +133,7 @@ export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
         elementCount++;
         let atRootElement = (elementCount === 1);
         let element = elementAnalyzer.analyze(node, atRootElement);
-        if (self.debug.enabled) self.debug("{{link-to}} analyzed:", element.forOptimizer(self.cssBlocksOptions).toString());
+        if (self.debug.enabled) self.debug("{{link-to}} analyzed:", element.class.forOptimizer(self.cssBlocksOptions).toString());
       },
 
       BlockStatement(node: AST.BlockStatement) {
@@ -141,14 +141,14 @@ export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
         elementCount++;
         let atRootElement = (elementCount === 1);
         let element = elementAnalyzer.analyze(node, atRootElement);
-        if (self.debug.enabled) self.debug("{{#link-to}} analyzed:", element.forOptimizer(self.cssBlocksOptions).toString());
+        if (self.debug.enabled) self.debug("{{#link-to}} analyzed:", element.class.forOptimizer(self.cssBlocksOptions).toString());
       },
 
       ElementNode(node) {
         elementCount++;
         let atRootElement = (elementCount === 1);
         let element = elementAnalyzer.analyze(node, atRootElement);
-        if (self.debug.enabled) self.debug("Element analyzed:", element.forOptimizer(self.cssBlocksOptions).toString());
+        if (self.debug.enabled) self.debug("Element analyzed:", element.class.forOptimizer(self.cssBlocksOptions).toString());
       },
     });
     return analysis;

--- a/packages/@css-blocks/glimmer/src/Analyzer.ts
+++ b/packages/@css-blocks/glimmer/src/Analyzer.ts
@@ -15,15 +15,12 @@ import * as debugGenerator from "debug";
 import { postcss } from "opticss";
 
 import { ElementAnalyzer } from "./ElementAnalyzer";
+import { isEmberBuiltIn } from "./EmberBuiltins";
 import { Resolver } from "./Resolver";
 import { TEMPLATE_TYPE } from "./Template";
 
 export type AttributeContainer = Block | BlockClass;
 export type GlimmerAnalysis = Analysis<TEMPLATE_TYPE>;
-
-function isLinkTo(node: AST.MustacheStatement | AST.BlockStatement): boolean {
-  return node.path.original === "link-to";
-}
 
 export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
   blockFactory: BlockFactory;
@@ -129,19 +126,21 @@ export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
     let elementAnalyzer = new ElementAnalyzer(analysis, this.cssBlocksOptions);
     traverse(ast, {
       MustacheStatement(node: AST.MustacheStatement) {
-        if (!isLinkTo(node)) { return; }
+        const name = node.path.original;
+        if (!isEmberBuiltIn(name)) { return; }
         elementCount++;
-        let atRootElement = (elementCount === 1);
-        let element = elementAnalyzer.analyze(node, atRootElement);
-        if (self.debug.enabled) self.debug("{{link-to}} analyzed:", element.class.forOptimizer(self.cssBlocksOptions).toString());
+        const atRootElement = (elementCount === 1);
+        const element = elementAnalyzer.analyze(node, atRootElement);
+        if (self.debug.enabled) self.debug(`{{${name}}} analyzed:`, element.class.forOptimizer(self.cssBlocksOptions).toString());
       },
 
       BlockStatement(node: AST.BlockStatement) {
-        if (!isLinkTo(node)) { return; }
+        const name = node.path.original;
+        if (!isEmberBuiltIn(name)) { return; }
         elementCount++;
-        let atRootElement = (elementCount === 1);
-        let element = elementAnalyzer.analyze(node, atRootElement);
-        if (self.debug.enabled) self.debug("{{#link-to}} analyzed:", element.class.forOptimizer(self.cssBlocksOptions).toString());
+        const atRootElement = (elementCount === 1);
+        const element = elementAnalyzer.analyze(node, atRootElement);
+        if (self.debug.enabled) self.debug(`{{#${name}}} analyzed:`, element.class.forOptimizer(self.cssBlocksOptions).toString());
       },
 
       ElementNode(node) {

--- a/packages/@css-blocks/glimmer/src/ClassnamesHelperGenerator.ts
+++ b/packages/@css-blocks/glimmer/src/ClassnamesHelperGenerator.ts
@@ -75,6 +75,13 @@ export function classnamesHelper(rewrite: IndexedClassRewrite<Style>, element: T
   );
 }
 
+export function classnamesSubexpr(rewrite: IndexedClassRewrite<Style>, element: TemplateElement): AST.SubExpression {
+  return builders.sexpr(
+    builders.path(CLASSNAMES_HELPER_NAME),
+    constructArgs(rewrite, element),
+  );
+}
+
 // tslint:disable-next-line:prefer-whatever-to-any
 function constructArgs(rewrite: IndexedClassRewrite<any>, element: TemplateElement): AST.Expression[] {
   let expr = new Array<AST.Expression>();
@@ -134,7 +141,7 @@ function constructSourceArgs(rewrite: IndexedClassRewrite<any>, element: Templat
 function constructTernary(classes: DynamicClasses<TernaryAST>, rewrite: IndexedClassRewrite<Style>): AST.Expression[] {
   let expr = new Array<AST.Expression>();
   // The boolean expression
-  expr.push(classes.condition);
+  expr.push(classes.condition!);
   // The true styles
   if (isTrueCondition(classes)) {
     let trueClasses = resolveInheritance(classes.whenTrue, rewrite);
@@ -249,10 +256,10 @@ function moustacheToExpression(expr: AST.MustacheStatement): AST.Expression {
 }
 
 function moustacheToStringExpression(stringExpression: StringAST): AST.Expression {
-  if (stringExpression.type === "ConcatStatement") {
+  if (stringExpression!.type === "ConcatStatement") {
     return builders.sexpr(
       builders.path(CONCAT_HELPER_NAME),
-      stringExpression.parts.reduce(
+      (stringExpression as AST.ConcatStatement).parts.reduce(
         (arr, val) => {
           if (val.type === "TextNode") {
             arr.push(builders.string(val.chars));
@@ -263,7 +270,7 @@ function moustacheToStringExpression(stringExpression: StringAST): AST.Expressio
         },
         new Array<AST.Expression>()));
   } else {
-    return moustacheToExpression(stringExpression);
+    return moustacheToExpression(stringExpression as AST.MustacheStatement);
   }
 }
 

--- a/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
+++ b/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
@@ -1,26 +1,22 @@
-import { AttrValue, Block, BlockClass, DynamicClasses, ElementAnalysis, ResolvedConfiguration as CSSBlocksConfiguration } from "@css-blocks/core";
+import {
+  AttrValue,
+  Block,
+  BlockClass,
+  ElementAnalysis,
+  ResolvedConfiguration as CSSBlocksConfiguration,
+} from "@css-blocks/core";
 import { AST, print } from "@glimmer/syntax";
 import { SourceLocation, SourcePosition } from "@opticss/element-analysis";
-import { assertNever } from "@opticss/util";
 import * as debugGenerator from "debug";
 
 import { GlimmerAnalysis } from "./Analyzer";
 import { ResolvedFile } from "./Template";
 import { cssBlockError } from "./utils";
 
-export type TernaryExpression = AST.Expression;
-export type StringExpression = AST.MustacheStatement | AST.ConcatStatement;
+export type TernaryExpression = AST.Expression | null;
+export type StringExpression = AST.MustacheStatement | AST.ConcatStatement | null;
 export type BooleanExpression = AST.Expression | AST.MustacheStatement;
 export type TemplateElement  = ElementAnalysis<BooleanExpression, StringExpression, TernaryExpression>;
-export type AnalysisElement  = ElementAnalysis<null, null, null>;
-
-type RewriteAnalysis = {
-  element: TemplateElement;
-  storeConditionals: true;
-} | {
-  element: AnalysisElement;
-  storeConditionals: false;
-};
 
 // TODO: The state namespace should come from a config option.
 const STATE = /^state:(?:([^.]+)\.)?([^.]+)$/;
@@ -28,6 +24,8 @@ const STYLE_IF = "style-if";
 const STYLE_UNLESS = "style-unless";
 
 const debug = debugGenerator("css-blocks:glimmer:element-analyzer");
+
+type AnalyzableNodes = AST.ElementNode | AST.BlockStatement | AST.MustacheStatement;
 
 export class ElementAnalyzer {
   analysis: GlimmerAnalysis;
@@ -41,27 +39,37 @@ export class ElementAnalyzer {
     this.template = analysis.template;
     this.cssBlocksOpts = cssBlocksOpts;
   }
-  analyze(node: AST.ElementNode, atRootElement: boolean): AnalysisElement {
-    let element = this.analysis.startElement<null, null, null>(nodeLocation(node), node.tag);
-    this._analyze(node, atRootElement, {element, storeConditionals: false});
+
+  analyze(node: AnalyzableNodes, atRootElement: boolean): TemplateElement {
+    let label = isElementNode(node) ? node.tag : node.path.original as string;
+    let element = this.analysis.startElement<BooleanExpression, StringExpression, TernaryExpression>(nodeLocation(node), label);
+    element = this._analyze(node, atRootElement, element, false);
     this.analysis.endElement(element);
     return element;
   }
-  analyzeForRewrite(node: AST.ElementNode, atRootElement: boolean): TemplateElement {
-    let element = new ElementAnalysis<BooleanExpression, StringExpression, TernaryExpression>(nodeLocation(node), node.tag);
-    this._analyze(node, atRootElement, {element, storeConditionals: true});
+
+  analyzeForRewrite(node: AnalyzableNodes, atRootElement: boolean): TemplateElement {
+    let label = isElementNode(node) ? node.tag : node.path.original as string;
+    let element = new ElementAnalysis<BooleanExpression, StringExpression, TernaryExpression>(nodeLocation(node), label);
+    this._analyze(node, atRootElement, element, true);
     return element;
   }
 
-  // tslint:disable-next-line:prefer-whatever-to-any
-  private debugAnalysis(node: AST.ElementNode, atRootElement: boolean, element: ElementAnalysis<any, any, any>) {
+  private debugAnalysis(node: AnalyzableNodes, atRootElement: boolean, element: TemplateElement) {
     if (!debug.enabled) return;
-    let startTag = `<${node.tag} ${node.attributes.map(a => print(a)).join(" ")}>`;
-    debug(`Element ${startTag} is ${atRootElement ? "the root " : "a sub"}element at ${this.debugTemplateLocation(node)}`);
+    let startTag = "";
+    if (isElementNode(node)) {
+      startTag = `<${node.tag} ${node.attributes.map(a => print(a)).join(" ")}>`;
+      debug(`Element ${startTag} is ${atRootElement ? "the root " : "a sub"}element at ${this.debugTemplateLocation(node)}`);
+    }
+    else {
+      startTag = `{{${node.path.original} ${node.params.map(a => print(a)).join(" ")} ${node.hash.pairs.map((h) => print(h)).join(" ")}}}`;
+      debug(`Component ${startTag} is ${atRootElement ? "the root " : "a sub"}element at ${this.debugTemplateLocation(node)}`);
+    }
     debug(`↳ Analyzed as: ${element.forOptimizer(this.cssBlocksOpts)[0].toString()}`);
   }
 
-  private debugTemplateLocation(node: AST.ElementNode) {
+  private debugTemplateLocation(node: AnalyzableNodes) {
     let templatePath = this.cssBlocksOpts.importer.debugIdentifier(this.template.identifier, this.cssBlocksOpts);
     return `${templatePath}:${node.loc.start.line}:${node.loc.start.column}`;
   }
@@ -70,30 +78,66 @@ export class ElementAnalyzer {
   }
 
   private _analyze(
-    node: AST.ElementNode,
+    node: AnalyzableNodes,
     atRootElement: boolean,
-    analysis: RewriteAnalysis,
-  ) {
+    element: TemplateElement,
+    storeConditionals: boolean,
+  ): TemplateElement {
 
-    // The root element gets the block's root class automatically.
+    // The root element gets the block"s root class automatically.
     if (atRootElement) {
-      analysis.element.addStaticClass(this.block.rootClass);
+      element.addStaticClass(this.block.rootClass);
     }
 
     // Find the class attribute and process.
-    let classAttr: AST.AttrNode | undefined =
-      node.attributes.find(n => n.name === "class");
-
-    if (classAttr) this.processClass(classAttr, analysis);
-
-    for (let attribute of node.attributes) {
-      if (!STATE.test(attribute.name)) continue;
-      this.processState(RegExp.$1, RegExp.$2, attribute, analysis);
+    if (node.type === "ElementNode") {
+      let classAttr: AST.AttrNode | undefined = node.attributes.find(n => n.name === "class");
+      if (classAttr) { this.processClass(classAttr, element, storeConditionals); }
     }
 
-    analysis.element.seal();
-    this.debugAnalysis(node, atRootElement, analysis.element);
-    return;
+    else {
+      let classAttr: AST.HashPair | undefined = node.hash.pairs.find(n => n.key === "class");
+      if (classAttr) { this.processClass(classAttr, element, storeConditionals); }
+    }
+
+    // Only ElementNodes may use states right now.
+    if (isElementNode(node)) {
+      for (let attribute of node.attributes) {
+        if (!STATE.test(attribute.name)) { continue; }
+        this.processState(RegExp.$1, RegExp.$2, attribute, element, storeConditionals);
+      }
+    }
+
+    // Only `{{link-to}}` for now. Uses `[state|active]` if present.
+    // Track potential use of the active state on a new element so
+    // we can re-use existing dynamic class rewriting logic on this
+    // element. The `activeClass` attribute will be automagically passed
+    // to the helper by the rewriter later.
+    // TODO: Suuuper messy. All of rewriting needs to be refactored from the ground up...
+    else if (node.path.original === "link-to") {
+      element.seal();
+      this.debugAnalysis(node, atRootElement, element);
+      let klasses = element.classesFound();
+      if (!storeConditionals) {
+        this.analysis.endElement(element);
+        element = this.analysis.startElement(element.sourceLocation);
+      }
+      else {
+        element = new ElementAnalysis<BooleanExpression, StringExpression, TernaryExpression>(nodeLocation(node));
+      }
+      for (let style of klasses) {
+        let attrs = style.resolveAttributeValues("[state|active]");
+        if (!attrs.size) { continue; }
+        element.addStaticClass(style);
+        for (let entry of attrs) {
+          element.addStaticAttr(style, entry[1]);
+        }
+      }
+    }
+
+    element.seal();
+    this.debugAnalysis(node, atRootElement, element);
+    return element;
   }
 
   private lookupClasses(classes: string, node: AST.Node): Array<BlockClass> {
@@ -124,27 +168,32 @@ export class ElementAnalyzer {
   /**
    * Adds blocks and block classes to the current node from the class attribute.
    */
-  private processClass(node: AST.AttrNode, analysis: RewriteAnalysis): void {
-    let statements: Array<AST.TextNode | AST.MustacheStatement>;
+  private processClass(node: AST.AttrNode | AST.HashPair, element: TemplateElement, storeConditionals: boolean): void {
+    let statements: AST.Node[];
 
-    if (isConcatStatement(node.value)) {
-      statements = node.value.parts;
+    let value = node.value;
+
+    if (isConcatStatement(value)) {
+      statements = value.parts;
     } else {
       statements = [node.value];
     }
+
     for (let statement of statements) {
-      if (isTextNode(statement)) {
-        for (let container of this.lookupClasses(statement.chars, statement)) {
-          analysis.element.addStaticClass(container);
+      if (isTextNode(statement) || isStringLiteral(statement)) {
+        let value = isTextNode(statement) ? statement.chars : statement.value;
+        for (let container of this.lookupClasses(value, statement)) {
+          element.addStaticClass(container);
         }
-      } else if (isMustacheStatement(statement)) {
+      }
+      else if (isMustacheStatement(statement) || isSubExpression(statement)) {
         let helperType = isStyleIfHelper(statement);
 
         // If this is a `{{style-if}}` or `{{style-unless}}` helper:
         if (helperType) {
           let condition = statement.params[0];
-          let whenTrue: Array<BlockClass> | undefined = undefined;
-          let whenFalse: Array<BlockClass> | undefined = undefined;
+          let whenTrue: Array<BlockClass> = [];
+          let whenFalse: Array<BlockClass> = [];
           let mainBranch = statement.params[1];
           let elseBranch = statement.params[2];
 
@@ -173,17 +222,18 @@ export class ElementAnalyzer {
               throw cssBlockError(`{{${helperType}}} expects a string literal as its third argument.`, elseBranch, this.template);
             }
           }
-          if (analysis.storeConditionals) {
-            analysis.element.addDynamicClasses(dynamicClasses(condition, whenTrue, whenFalse));
+          if (storeConditionals) {
+            // element.addDynamicClasses(dynamicClasses(condition, whenTrue, whenFalse));
+            element.addDynamicClasses({ condition, whenTrue, whenFalse });
           } else {
-            analysis.element.addDynamicClasses(dynamicClasses(null, whenTrue, whenFalse));
+            element.addDynamicClasses({ condition: null, whenTrue, whenFalse });
           }
 
         } else {
           throw cssBlockError(`Only {{style-if}} or {{style-unless}} helpers are allowed in class attributes.`, node, this.template);
         }
       } else {
-        assertNever(statement);
+        throw cssBlockError(`Only string literals, {{style-if}} or {{style-unless}} are allowed in class attributes.`, node, this.template);
       }
     }
   }
@@ -195,13 +245,14 @@ export class ElementAnalyzer {
     blockName: string | undefined,
     stateName: string,
     node: AST.AttrNode,
-    analysis: RewriteAnalysis,
+    element: TemplateElement,
+    storeConditionals: boolean,
   ): void {
     let stateBlock = blockName ? this.block.getReferencedBlock(blockName) : this.block;
     if (stateBlock === null) {
       throw cssBlockError(`No block named ${blockName} referenced from ${this.debugBlockPath()}`, node, this.template);
     }
-    let containers = analysis.element.classesForBlock(stateBlock);
+    let containers = element.classesForBlock(stateBlock);
     if (containers.length === 0) {
       throw cssBlockError(`No block or class from ${blockName || "the default block"} is assigned to the element so a state from that block cannot be used.`, node, this.template);
     }
@@ -225,17 +276,17 @@ export class ElementAnalyzer {
       if (stateGroup && staticSubStateName) {
         state = stateGroup.resolveValue(staticSubStateName);
         if (state) {
-          analysis.element.addStaticAttr(container, state);
+          element.addStaticAttr(container, state);
         } else {
           throw cssBlockError(`No sub-state found named ${staticSubStateName} in state ${stateName} for ${container.asSource()} in ${blockName || "the default block"}.`, node, this.template);
         }
       } else if (stateGroup) {
         if (stateGroup.hasResolvedValues()) {
           if (dynamicSubState) {
-            if (analysis.storeConditionals) {
-              analysis.element.addDynamicGroup(container, stateGroup, dynamicSubState);
+            if (storeConditionals) {
+              element.addDynamicGroup(container, stateGroup, dynamicSubState);
             } else {
-              analysis.element.addDynamicGroup(container, stateGroup, null);
+              element.addDynamicGroup(container, stateGroup, null);
             }
           } else {
             // TODO: when we add default sub states this is where that will go.
@@ -247,13 +298,9 @@ export class ElementAnalyzer {
               throw cssBlockError(`The dynamic statement for a boolean state must be set to a mustache statement with no additional text surrounding it.`, dynamicSubState, this.template);
             }
             let state = stateGroup.presenceRule;
-            if (analysis.storeConditionals) {
-              analysis.element.addDynamicAttr(container, state!, dynamicSubState);
-            } else {
-              analysis.element.addDynamicAttr(container,  state!, null);
-            }
+            element.addDynamicAttr(container, state!, dynamicSubState);
           } else {
-            analysis.element.addStaticAttr(container, stateGroup.presenceRule!);
+            element.addStaticAttr(container, stateGroup.presenceRule!);
           }
         }
       } else {
@@ -270,17 +317,23 @@ export class ElementAnalyzer {
 function isStringLiteral(value: AST.Node | undefined): value is AST.StringLiteral {
   return value !== undefined && value.type === "StringLiteral";
 }
-function isConcatStatement(value: AST.TextNode | AST.MustacheStatement | AST.ConcatStatement): value is AST.ConcatStatement {
-  return value.type === "ConcatStatement";
+function isConcatStatement(value: AST.Node | undefined): value is AST.ConcatStatement {
+  return !!value && value.type === "ConcatStatement";
 }
-function isTextNode(value: AST.TextNode | AST.MustacheStatement | AST.ConcatStatement): value is AST.TextNode {
-  return value.type === "TextNode";
+function isTextNode(value: AST.Node | undefined): value is AST.TextNode {
+  return !!value && value.type === "TextNode";
 }
-function isMustacheStatement(value: AST.TextNode | AST.MustacheStatement | AST.ConcatStatement): value is AST.MustacheStatement {
-  return value.type === "MustacheStatement";
+function isMustacheStatement(value: AST.Node | undefined): value is AST.MustacheStatement {
+  return !!value && value.type === "MustacheStatement";
+}
+function isSubExpression(value: AST.Node | undefined): value is AST.SubExpression {
+  return !!value && value.type === "SubExpression";
+}
+function isElementNode(value: AST.Node | undefined): value is AST.ElementNode {
+  return !!value && value.type === "ElementNode";
 }
 
-function isStyleIfHelper(node: AST.MustacheStatement): "style-if" | "style-unless" | undefined {
+function isStyleIfHelper(node: AST.MustacheStatement | AST.SubExpression): "style-if" | "style-unless" | undefined {
   if (node.path.type !== "PathExpression") { return undefined; }
   let parts: string[] = (node.path).parts;
   if (parts.length > 0) {
@@ -307,20 +360,4 @@ function nodeLocation(node: AST.Node): SourceLocation {
     column: node.loc.start.column,
   };
   return { start, end };
-}
-
-type BranchStyles = Array<BlockClass> | undefined;
-
-function dynamicClasses(condition: null, whenTrue: BranchStyles, whenFalse: BranchStyles): DynamicClasses<null>;
-function dynamicClasses(condition: AST.Expression, whenTrue: BranchStyles, whenFalse: BranchStyles): DynamicClasses<TernaryExpression>;
-function dynamicClasses(condition: AST.Expression | null, whenTrue: BranchStyles, whenFalse: BranchStyles): DynamicClasses<TernaryExpression | null> {
-  if (whenTrue && whenFalse) {
-    return { condition, whenTrue, whenFalse };
-  } else if (whenTrue) {
-    return { condition, whenTrue };
-  } else if (whenFalse) {
-    return { condition, whenFalse };
-  } else {
-    throw new Error("sometimes type checkers are dumb");
-  }
 }

--- a/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
+++ b/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
@@ -14,6 +14,8 @@ import { getEmberBuiltInStates, isEmberBuiltIn } from "./EmberBuiltins";
 import { ResolvedFile } from "./Template";
 import { cssBlockError } from "./utils";
 
+// Expressions may be null when ElementAnalyzer is used in the second pass analysis
+// to re-acquire analysis data for rewrites without storing AST nodes.
 export type TernaryExpression = AST.Expression | null;
 export type StringExpression = AST.MustacheStatement | AST.ConcatStatement | null;
 export type BooleanExpression = AST.Expression | AST.MustacheStatement;
@@ -230,7 +232,6 @@ export class ElementAnalyzer {
             }
           }
           if (forRewrite) {
-            // element.addDynamicClasses(dynamicClasses(condition, whenTrue, whenFalse));
             element.addDynamicClasses({ condition, whenTrue, whenFalse });
           } else {
             element.addDynamicClasses({ condition: null, whenTrue, whenFalse });

--- a/packages/@css-blocks/glimmer/src/EmberBuiltins.ts
+++ b/packages/@css-blocks/glimmer/src/EmberBuiltins.ts
@@ -1,0 +1,32 @@
+/**
+ * Ember Built-Ins are components that should be analyzed like regular
+ * elements. The Analyzer and Rewriter will process components defined
+ * in this file. All Built-Ins may have a `class` attribute that is
+ * Analyzed and Rewritten as expected. Built-Ins may define optional
+ * state mappings for state style applications managed internally to
+ * the helper or component (ex: `{{link-to}}`'s `activeClass`).
+ */
+import { whatever } from "@opticss/util";
+
+interface IBuiltIns {
+  "link-to": object;
+}
+
+const BUILT_INS: IBuiltIns = {
+  "link-to": {
+    "activeClass": "[state|active]",
+    "loadingClass": "[state|loading]",
+    "disabledClass": "[state|disabled]",
+  },
+};
+
+export type BuiltIns = keyof IBuiltIns;
+
+export function isEmberBuiltIn(name: whatever): name is keyof IBuiltIns {
+  if (typeof name === "string" && BUILT_INS[name]) { return true; }
+  return false;
+}
+
+export function getEmberBuiltInStates(name: BuiltIns): object {
+  return BUILT_INS[name];
+}

--- a/packages/@css-blocks/glimmer/src/Rewriter.ts
+++ b/packages/@css-blocks/glimmer/src/Rewriter.ts
@@ -17,6 +17,7 @@ import * as debugGenerator from "debug";
 import { GlimmerAnalysis } from "./Analyzer";
 import { classnamesHelper, classnamesSubexpr } from "./ClassnamesHelperGenerator";
 import { ElementAnalyzer } from "./ElementAnalyzer";
+import { getEmberBuiltInStates, isEmberBuiltIn } from "./EmberBuiltins";
 import { CONCAT_HELPER_NAME } from "./helpers";
 import { ResolvedFile, TEMPLATE_TYPE } from "./Template";
 
@@ -65,104 +66,93 @@ export class GlimmerRewriter implements ASTPlugin {
     if (!this.block) { return {}; }
     return {
       ElementNode: this.ElementNode.bind(this),
-      MustacheStatement: this.LinkToStatement.bind(this),
-      BlockStatement: this.LinkToStatement.bind(this),
+      MustacheStatement: this.BuiltinStatement.bind(this),
+      BlockStatement: this.BuiltinStatement.bind(this),
     };
   }
 
-  LinkToStatement(node: AST.MustacheStatement | AST.BlockStatement) {
-    if (node.path.original !== "link-to") { return; }
+  BuiltinStatement(node: AST.MustacheStatement | AST.BlockStatement) {
+    if (!isEmberBuiltIn(node.path.original)) { return; }
     this.elementCount++;
+
+    // Simple single space AST node to reuse.
+    const space: AST.Literal = this.syntax.builders.string(" ");
+    const attrToStateMap = getEmberBuiltInStates(node.path.original);
     let atRootElement = (this.elementCount === 1);
+
     // TODO: We use this to re-analyze elements in the rewriter.
     //       We've already done this work and should be able to
     //       re-use the data! Unfortunately, there are problems...
     //       See: https://github.com/linkedin/css-blocks/issues/84
-    let element = this.elementAnalyzer.analyzeForRewrite(node, atRootElement);
-    let rewrite = this.styleMapping.simpleRewriteMapping(element);
-    this.debug(element.forOptimizer(this.cssBlocksOpts)[0].toString());
+    const attrMap = this.elementAnalyzer.analyzeForRewrite(node, atRootElement);
 
     // Remove all the source attributes for styles.
-    node.hash.pairs = node.hash.pairs.filter(a => !STYLE_ATTR.test(a.key)).filter(a => a.key !== "activeClass");
+    node.hash.pairs = node.hash.pairs.filter(a => !STYLE_ATTR.test(a.key)).filter(a => !attrToStateMap[a.key]);
 
-    // It's a simple text node of static classes.
-    let staticValue: AST.Literal | null = null;
-    let dynamicValue: AST.Expression | null = null;
+    for (let attr of Object.keys(attrMap)) {
+      let element = attrMap[attr];
+      let rewrite = this.styleMapping.simpleRewriteMapping(element);
+      this.debug(element.forOptimizer(this.cssBlocksOpts)[0].toString());
+      let staticValue: AST.Literal | null = null;
+      let dynamicValue: AST.Expression | null = null;
 
-    // Set a static class AST node if needed.
-    if (rewrite.staticClasses.length) {
-      staticValue = this.syntax.builders.string(rewrite.staticClasses.join(" "));
-    }
-
-    // Set a dynamic classes AST node if needed.
-    if (rewrite.dynamicClasses.length) {
-      dynamicValue = classnamesSubexpr(rewrite, element);
-    }
-
-    // If no classes, return.
-    if (!staticValue && !dynamicValue) { return; }
-
-    // If both static and dynamic, concat them together, otherwise use one or the other.
-    const classValue = (staticValue && dynamicValue) ? this.syntax.builders.sexpr(this.syntax.builders.path(CONCAT_HELPER_NAME), [staticValue, dynamicValue]) : (staticValue || dynamicValue);
-
-    // Add the new class attribute.
-    let hash = this.syntax.builders.pair("class", classValue!);
-    node.hash.pairs.push(hash);
-
-    // For every class on the element...
-    let strings: string[] = [];
-    for (let klass of element.classesFound()) {
-      // Check to see if it has an active class,
-      let activeClass = klass.resolveAttribute("[state|active]");
-      if (activeClass && activeClass.presenceRule) {
-        // If yes, get the re-written class name and preserve it in AST form.
-        let rewritten = this.styleMapping.optimizedMap.getRewriteOf({
-          name: "class",
-          value: activeClass.presenceRule.cssClasses(this.cssBlocksOpts).join(" "),
-        });
-        if (!rewritten) { continue; }
-        strings.push(rewritten.value);
+      // Set a static class AST node if needed.
+      if (rewrite.staticClasses.length) {
+        staticValue = this.syntax.builders.string(rewrite.staticClasses.join(" "));
       }
-    }
 
-    // If there are active classes, pass them to the helper.
-    if (strings.length) {
-      let activeHash = this.syntax.builders.pair("activeClass", this.syntax.builders.string(strings.join(" ")));
-      node.hash.pairs.push(activeHash);
+      // Set a dynamic classes AST node if needed.
+      if (rewrite.dynamicClasses.length) {
+        dynamicValue = classnamesSubexpr(rewrite, element);
+      }
+
+      // If no classes, return.
+      if (!staticValue && !dynamicValue) { return; }
+
+      // If both static and dynamic, concat them together, otherwise use one or the other.
+      const attrValue = (staticValue && dynamicValue) ? this.syntax.builders.sexpr(this.syntax.builders.path(CONCAT_HELPER_NAME), [staticValue, space, dynamicValue]) : (staticValue || dynamicValue);
+
+      // Add the new attribute.
+      let hash = this.syntax.builders.pair(attr, attrValue!);
+      node.hash.pairs.push(hash);
     }
   }
 
   ElementNode(node: AST.ElementNode): void {
     this.elementCount++;
     let atRootElement = (this.elementCount === 1);
-    // TODO: We use this to re-analyze elements in the rewriter.
-    //       We've already done this work and should be able to
-    //       re-use the data! Unfortunately, there are problems...
-    //       See: https://github.com/linkedin/css-blocks/issues/84
-    let element = this.elementAnalyzer.analyzeForRewrite(node, atRootElement);
-    this.debug(element.forOptimizer(this.cssBlocksOpts)[0].toString());
-    let rewrite = this.styleMapping.simpleRewriteMapping(element);
+    const space: AST.TextNode = this.syntax.builders.text(" ");
+    let attrMap = this.elementAnalyzer.analyzeForRewrite(node, atRootElement);
 
     // Remove all the source attributes for styles.
     node.attributes = node.attributes.filter(a => !STYLE_ATTR.test(a.name));
 
-    // It's a simple text node of static classes.
-    let staticValue: AST.TextNode | null = null;
-    let dynamicValue: AST.MustacheStatement | null = null;
+    for (let attr of Object.keys(attrMap)) {
+      let element = attrMap[attr];
+      let rewrite = this.styleMapping.simpleRewriteMapping(element);
+      this.debug(element.forOptimizer(this.cssBlocksOpts)[0].toString());
+      let staticValue: AST.TextNode | null = null;
+      let dynamicValue: AST.MustacheStatement | null = null;
 
-    if (rewrite.staticClasses.length) {
-      staticValue = this.syntax.builders.text(rewrite.staticClasses.join(" "));
+      // Set a static class AST node if needed.
+      if (rewrite.staticClasses.length) {
+        staticValue = this.syntax.builders.text(rewrite.staticClasses.join(" "));
+      }
+
+      // Set a dynamic classes AST node if needed.
+      if (rewrite.dynamicClasses.length) {
+        dynamicValue = classnamesHelper(rewrite, element);
+      }
+
+      // If no classes, return.
+      if (!staticValue && !dynamicValue) { return; }
+
+      // If both static and dynamic, concat them together, otherwise use one or the other.
+      const attrValue = (staticValue && dynamicValue) ? this.syntax.builders.concat([staticValue, space, dynamicValue]) : (staticValue || dynamicValue);
+
+      // Add the new attribute.
+      let hash = this.syntax.builders.attr(attr, attrValue!);
+      node.attributes.push(hash);
     }
-
-    if (rewrite.dynamicClasses.length) {
-      dynamicValue = classnamesHelper(rewrite, element);
-    }
-
-    if (!staticValue && !dynamicValue) { return; }
-
-    const classValue = (staticValue && dynamicValue) ? this.syntax.builders.concat([staticValue, dynamicValue]) : (staticValue || dynamicValue);
-
-    node.attributes.unshift(this.syntax.builders.attr("class", classValue!));
-
   }
 }

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/external.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/external.css
@@ -1,0 +1,16 @@
+:scope {
+  block-name: external;
+  background: #ccc;
+}
+
+.link-1 {
+  background: blue;
+}
+
+.link-3 {
+  color: pink;
+}
+
+.link-3[state|active] {
+  color: purple
+}

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/stylesheet.css
@@ -1,0 +1,19 @@
+@block external from "./external.css";
+@block util from "./util.css";
+
+:scope {
+  extends: external;
+  color: red;
+}
+
+.link-1 {
+  color: yellow;
+}
+
+.link-2 {
+  color: green;
+}
+
+.link-2[state|active] {
+  color: blue;
+}

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/stylesheet.css
@@ -17,3 +17,19 @@
 .link-2[state|active] {
   color: blue;
 }
+
+.link-4 {
+  color: gray;
+}
+
+.link-4[state|active] {
+  color: green;
+}
+
+.link-4[state|loading] {
+  color: yellow;
+}
+
+.link-4[state|disabled] {
+  color: red;
+}

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/template.hbs
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/template.hbs
@@ -13,4 +13,8 @@
 
   {{link-to "Inline Form, External State" "inline-form-active" class="external.link-3" activeClass="whatever"}}
   {{#link-to "block-form-active" class="external.link-3"}}Block Form, External State{{/link-to}}
+
+  {{link-to "Inline Form, All States" "inline-form-active" class="link-4" loadingClass="whatever"}}
+  {{#link-to "block-form-active" class="link-4" disabledClass="whatever"}}Block Form, All States{{/link-to}}
+
 </div>

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/template.hbs
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/template.hbs
@@ -1,0 +1,16 @@
+<div>
+  {{link-to "Inline Form" "inline-form" class="link-1"}}
+  {{#link-to "block-form" class="link-1 util.util"}}Block Form{{/link-to}}
+
+  {{link-to "Inline Form" "inline-form-active" class="link-2"}}
+  {{#link-to "block-form-active" class="link-2"}}Block Form{{/link-to}}
+
+  {{link-to "Dynamic Inline Form" "inline-form-active" class=(style-if foo "link-2") activeClass="whatever"}}
+  {{#link-to "block-form-active" class=(style-if foo "link-2")}}Dynamic Block Form{{/link-to}}
+
+  {{link-to "Inline Form, Inherited State" "inline-form-active" class="link-3" activeClass="whatever"}}
+  {{#link-to "block-form-active" class="link-3"}}Block Form, Inherited State{{/link-to}}
+
+  {{link-to "Inline Form, External State" "inline-form-active" class="external.link-3" activeClass="whatever"}}
+  {{#link-to "block-form-active" class="external.link-3"}}Block Form, External State{{/link-to}}
+</div>

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/util.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/util.css
@@ -1,0 +1,3 @@
+.util {
+  border: 1px solid blue;
+}

--- a/packages/@css-blocks/glimmer/test/template-rewrite-test.ts
+++ b/packages/@css-blocks/glimmer/test/template-rewrite-test.ts
@@ -95,7 +95,7 @@ describe("Template Rewriting", function() {
         <div class={{-css-blocks-classnames 1 1 0 isWorld 0 1 0 "b" 0}}>World</div>
       </div>
     `));
-});
+  });
 
   it("rewrites styles from dynamic attributes from readme", async function() {
     let projectDir = fixture("readme-app");
@@ -118,6 +118,46 @@ describe("Template Rewriting", function() {
       .g { width: 20%; }
       .h { width: calc(20% - 20px); margin-right: 20px; }
       .i { width: 80%; }
+    `),
+    );
+  });
+
+  it.only("rewrites link-to helpers", async function() {
+    let projectDir = fixture("styled-app");
+    let analyzer = new GlimmerAnalyzer({}, {}, moduleConfig);
+    let templatePath = fixture("styled-app/src/ui/components/with-link-to/template.hbs");
+    let result = await pipeline(projectDir, analyzer, "with-link-to", templatePath);
+
+    // TODO why is `f` class both static and dynamic?
+    assert.deepEqual(minify(print(result.ast)), minify(`
+    <div class="e a">
+      {{link-to "Inline Form" "inline-form" class="f b"}}
+      {{#link-to "block-form" class="f b i"}}Block Form{{/link-to}}
+
+      {{link-to "Inline Form" "inline-form-active" class="c" activeClass="d"}}
+      {{#link-to "block-form-active" class="c" activeClass="d"}}Block Form{{/link-to}}
+
+      {{link-to "Dynamic Inline Form" "inline-form-active" class=(-css-blocks-classnames 1 1 0 foo 1 0 0 "c" 0) activeClass="d"}}
+      {{#link-to "block-form-active" class=(-css-blocks-classnames 1 1 0 foo 1 0 0 "c" 0) activeClass="d"}}Dynamic Block Form{{/link-to}}
+
+      {{link-to "Inline Form, Inherited State" "inline-form-active" class="g" activeClass="h"}}
+      {{#link-to "block-form-active" class="g" activeClass="h"}}Block Form, Inherited State{{/link-to}}
+
+      {{link-to "Inline Form, External State" "inline-form-active" class="g" activeClass="h"}}
+      {{#link-to "block-form-active" class="g" activeClass="h"}}Block Form, External State{{/link-to}}
+    </div>
+    `));
+
+    assert.deepEqual(minify(result.css.toString()), minify(`
+      .a { color: red; }
+      .b { color: yellow; }
+      .c { color: green; }
+      .d { color: blue; }
+      .e { background: #ccc; }
+      .f { background: blue; }
+      .g { color: pink; }
+      .h { color: purple }
+      .i { border: 1px solid blue; }
     `),
     );
   });

--- a/packages/@css-blocks/glimmer/test/template-rewrite-test.ts
+++ b/packages/@css-blocks/glimmer/test/template-rewrite-test.ts
@@ -122,7 +122,7 @@ describe("Template Rewriting", function() {
     );
   });
 
-  it.only("rewrites link-to helpers", async function() {
+  it("rewrites link-to helpers", async function() {
     let projectDir = fixture("styled-app");
     let analyzer = new GlimmerAnalyzer({}, {}, moduleConfig);
     let templatePath = fixture("styled-app/src/ui/components/with-link-to/template.hbs");
@@ -130,9 +130,9 @@ describe("Template Rewriting", function() {
 
     // TODO why is `f` class both static and dynamic?
     assert.deepEqual(minify(print(result.ast)), minify(`
-    <div class="e a">
-      {{link-to "Inline Form" "inline-form" class="f b"}}
-      {{#link-to "block-form" class="f b i"}}Block Form{{/link-to}}
+    <div class="i a">
+      {{link-to "Inline Form" "inline-form" class="j b"}}
+      {{#link-to "block-form" class="j b m"}}Block Form{{/link-to}}
 
       {{link-to "Inline Form" "inline-form-active" class="c" activeClass="d"}}
       {{#link-to "block-form-active" class="c" activeClass="d"}}Block Form{{/link-to}}
@@ -140,11 +140,14 @@ describe("Template Rewriting", function() {
       {{link-to "Dynamic Inline Form" "inline-form-active" class=(-css-blocks-classnames 1 1 0 foo 1 0 0 "c" 0) activeClass="d"}}
       {{#link-to "block-form-active" class=(-css-blocks-classnames 1 1 0 foo 1 0 0 "c" 0) activeClass="d"}}Dynamic Block Form{{/link-to}}
 
-      {{link-to "Inline Form, Inherited State" "inline-form-active" class="g" activeClass="h"}}
-      {{#link-to "block-form-active" class="g" activeClass="h"}}Block Form, Inherited State{{/link-to}}
+      {{link-to "Inline Form, Inherited State" "inline-form-active" class="k" activeClass="l"}}
+      {{#link-to "block-form-active" class="k" activeClass="l"}}Block Form, Inherited State{{/link-to}}
 
-      {{link-to "Inline Form, External State" "inline-form-active" class="g" activeClass="h"}}
-      {{#link-to "block-form-active" class="g" activeClass="h"}}Block Form, External State{{/link-to}}
+      {{link-to "Inline Form, External State" "inline-form-active" class="k" activeClass="l"}}
+      {{#link-to "block-form-active" class="k" activeClass="l"}}Block Form, External State{{/link-to}}
+
+      {{link-to "Inline Form, All States" "inline-form-active" class="e" activeClass="f" loadingClass="g" disabledClass="h"}}
+      {{#link-to "block-form-active" class="e" activeClass="f" loadingClass="g" disabledClass="h"}}Block Form, All States{{/link-to}}
     </div>
     `));
 
@@ -153,11 +156,15 @@ describe("Template Rewriting", function() {
       .b { color: yellow; }
       .c { color: green; }
       .d { color: blue; }
-      .e { background: #ccc; }
-      .f { background: blue; }
-      .g { color: pink; }
-      .h { color: purple }
-      .i { border: 1px solid blue; }
+      .e { color: gray; }
+      .f { color: green; }
+      .g { color: yellow; }
+      .h { color: red; }
+      .i { background: #ccc; }
+      .j { background: blue; }
+      .k { color: pink; }
+      .l { color: purple }
+      .m { border: 1px solid blue; }
     `),
     );
   });


### PR DESCRIPTION
## Problem 
In Ember, the built in `{{link-to}}` component internally applies an `active`, `loading` or `disabled` class when the application's current active route matches the route, is loading, or the link is disabled. In CSS Blocks, we need a method to style these internally managed `{{link-to}}` states. 

## Solution
The built in `{{link-to}}` helper has an attributes that enable developers to override the active, loading and disabled classes used by the component. A small change to the Glimmer analyzer and rewriter enable us to rewrite `{{link-to}}` like any other elements, but allow CSS Blocks to pass custom state styles.

Any `{{link-to}}` component discovered with one or more CSS Blocks classes applied to it will automatically have any `[state|active]`, `[state|loading]`, or `[state|disabled]` styles rewritten in to the component's `activeClass` hash value. Ex:

```css
/* stylesheet.css */
.link { color: red; }
.link[state|active] { color: green; }
.link[state|loading] { color: yellow; }
.link[state|disabled] { color: gray; }
```
```hbs
<div>
  {{link-to "My Link" "my-route" class="link"}}
</div>
```

is rewritten to


```css
/* stylesheet.css */
.link { color: red; }
.link--active { color: blue; }
.link--loading { color: yellow; }
.link--disabled { color: gray; }
```
```hbs
<div>
  {{link-to 
    "My Link" 
    "my-route" 
    class="link" 
    activeClass="link--active"
    loadingClass="link--loading"
    disabledClass="link--disabled"
  }}
</div>
```

The `style-if` and `style-unless` helpers are available to be used on `link-to` as well: 

```hbs
<div>
  {{link-to "My Link" "my-route" class=(style-if data "link")}}
</div>
```

Class inheritance and external block references work as expected.

## Implementation
The implementation internally generalizes the concept of `Ember Built-Ins`. In `@css-blocks/glimmer/src/BuiltIns.ts` we can define any number of components we want to treat like native elements. These Built-Ins may define zero to many state attribute mappings that will re-map the output classes of a Block to the component's defined style interface. We may want to consider using a similar implementation to enable user-defined component style interface mappings, or implement a Block passing feature (allow users to pass a custom implemented Block to a CSS Blocks component). For now though, the concept remains an internal construct.