### PR TITLE
fix(webpack): Compatibility w/ webpack-dev-server.

### DIFF
--- a/packages/@css-blocks/webpack/src/Plugin.ts
+++ b/packages/@css-blocks/webpack/src/Plugin.ts
@@ -117,6 +117,9 @@ export class CssBlocksPlugin
       entries = flatten<string>(objectValues(webpackEntry));
     }
 
+    // Zomg webpack-dev-server, injecting fake paths into the entry points.
+    entries = entries.filter(entry => !/\/webpack-dev-server\/|^webpack\/hot\/dev-server$/.test(entry));
+
     let pending: PendingResult = this.analyzer.analyze("", entries)
       // If analysis fails, drain our BlockFactory, add error to compilation error list and propagate.
       .catch((err: Error) => {

--- a/packages/@css-blocks/webpack/test/plugin-test.ts
+++ b/packages/@css-blocks/webpack/test/plugin-test.ts
@@ -42,6 +42,10 @@ export class PluginTest {
     });
   }
 
+  @skip @test "works with HotModuleReplacementPlugin"() {
+    return execTest("hello", undefined, "dev-server");
+  }
+
   @skip @test "integrates with templates"() {
     return templateConfig().then(config => {
       return runWebpackAsPromise(config).then(() => {

--- a/packages/@css-blocks/webpack/test/util/execTest.ts
+++ b/packages/@css-blocks/webpack/test/util/execTest.ts
@@ -7,12 +7,12 @@ import { LoaderOptions } from "../../src/LoaderOptions";
 import { WebpackAny } from "../../src/Plugin";
 import { EntryTypes, config as basicConfig } from "../configs/basicConfig";
 
-import { BLOCK_FIXTURES_DIRECTORY, DIST_DIRECTORY } from "./testPaths";
+import { BLOCK_FIXTURES_DIRECTORY, DIST_DIRECTORY, WEBPACK_DEV_SERVER_PATH } from "./testPaths";
 const CR = /\r/g;
 
 // This test harness was adapted from the sass-loader test suite.
 
-export function execTest(testId: string, options?: LoaderOptions, entryFormat: "string" | "object" | "array" = "string") {
+export function execTest(testId: string, options?: LoaderOptions, entryFormat: "string" | "object" | "array" | "dev-server" = "string") {
     const entryPath: string = path.join(BLOCK_FIXTURES_DIRECTORY, testId + ".block.css");
     let entry: EntryTypes = entryPath;
 
@@ -21,6 +21,9 @@ export function execTest(testId: string, options?: LoaderOptions, entryFormat: "
     }
     else if (entryFormat === "object") {
         entry = { main: entryPath };
+    }
+    else if (entryFormat === "dev-server") {
+        entry = [WEBPACK_DEV_SERVER_PATH, "webpack/hot/dev-server", entryPath];
     }
 
     return runWebpackAsPromise(basicConfig(entry, options))

--- a/packages/@css-blocks/webpack/test/util/testPaths.ts
+++ b/packages/@css-blocks/webpack/test/util/testPaths.ts
@@ -4,3 +4,4 @@ export const DIST_DIRECTORY = path.resolve(__dirname, "..", "..");
 export const FIXTURES_DIRECTORY = path.resolve(DIST_DIRECTORY, "..", "test", "fixtures");
 export const BLOCK_FIXTURES_DIRECTORY = path.resolve(FIXTURES_DIRECTORY, "blocks");
 export const BLOCK_LOADER_PATH = require.resolve("../../src/loader.js");
+export const WEBPACK_DEV_SERVER_PATH = path.join(__dirname, "node_modules", "webpack-dev-server", "client", "index?http://localhost:8080");


### PR DESCRIPTION
This fix filters out fake paths injected by the dev server. Doing so prevents the throwing of ENOENT errors when the Analyzer tries to open those fake paths. Fixes #163.

I've tested this manually by linking it into a project that uses webpack-dev-server and observing that compilation succeeds where it had previously failed.

The test I added fails with `Module build failed: Error: No rewriter` as do all but one of the existing Plugin tests when unskipped. (The outlier fails with a different error.) Since the existing tests have been skipped, I figure it's okay to do the same with this one.