### PR TITLE
fix: Properly output conflict resolutions for shorthands.

### DIFF
--- a/packages/@css-blocks/broccoli/src/Analyze.ts
+++ b/packages/@css-blocks/broccoli/src/Analyze.ts
@@ -111,7 +111,7 @@ export class CSSBlocksAnalyze extends BroccoliPlugin {
         let filename = filesystemPath || options.importer.debugIdentifier(block.identifier, options);
 
         // If this Block has a representation on disk, remove it from our output tree.
-        if (filesystemPath) {
+        if (filesystemPath && !!~filesystemPath.indexOf(output)) {
           debug(`Removing block file ${filesystemPath} from output.`);
           if (fs.existsSync(filesystemPath)) { fs.removeSync(filesystemPath); }
         }

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -1,3 +1,4 @@
+import * as debugGenerator from "debug";
 import { postcss } from "opticss";
 
 import { Block } from "../BlockTree";
@@ -17,6 +18,8 @@ import { importBlocks } from "./features/import-blocks";
 import { processDebugStatements } from "./features/process-debug-statements";
 import { BlockFactory } from "./index";
 import { Syntax } from "./preprocessing";
+
+const debug = debugGenerator("css-blocks:BlockParser");
 
 export interface ParsedSource {
   identifier: FileIdentifier;
@@ -63,6 +66,7 @@ export class BlockParser {
     let importer = this.config.importer;
     let debugIdent = importer.debugIdentifier(identifier, this.config);
     let sourceFile = importer.filesystemPath(identifier, this.config) || debugIdent;
+    debug(`Begin parse: "${debugIdent}"`);
 
     // Discover the block's preferred name.
     name = await discoverName(root, name, sourceFile);
@@ -71,25 +75,35 @@ export class BlockParser {
     let block = new Block(name, identifier, root);
 
     // Throw if we encounter any `!important` decls.
+    debug(` - Disallow Import`);
     await disallowImportant(root, sourceFile);
     // Discover and parse all block references included by this block.
+    debug(` - Import Blocks`);
     await importBlocks(block, this.factory, sourceFile);
     // Export all exported block references from this block.
-    await exportBlocks(block, sourceFile);
+    debug(` - Export Blocks`);
+    await exportBlocks(block, this.factory, sourceFile);
     // Handle any global attributes defined by this block.
+    debug(` - Global Attributes`);
     await globalAttributes(root, block, sourceFile);
     // Parse all block styles and build block tree.
+    debug(` - Construct Block`);
     await constructBlock(root, block, debugIdent);
     // Verify that external blocks referenced have been imported, have defined the attribute being selected, and have marked it as a global state.
+    debug(` - Assert Foreign Globals`);
     await assertForeignGlobalAttribute(root, block, debugIdent);
     // Construct block extensions and validate.
+    debug(` - Extend Block`);
     await extendBlock(root, block, debugIdent);
     // Validate that all required Styles are implemented.
+    debug(` - Implement Block`);
     await implementBlock(root, block, debugIdent);
     // Log any debug statements discovered.
+    debug(` - Process Debugs`);
     await processDebugStatements(root, block, debugIdent, this.config);
 
     // Return our fully constructed block.
+    debug(` - Complete`);
     return block;
   }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
@@ -42,7 +42,7 @@ export async function assertForeignGlobalAttribute(root: postcss.Root, block: Bl
           let otherBlock = block.getReferencedBlock(blockName.value);
           if (!otherBlock) {
             throw new errors.InvalidBlockSyntax(
-              `No block named ${blockName.value} found: ${rule.selector}`,
+              `No Block named "${blockName.value}" found in scope: ${rule.selector}`,
               loc(file, rule, node));
           }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
@@ -1,4 +1,3 @@
-import { ObjectDictionary } from "@opticss/util";
 import { postcss } from "opticss";
 
 import { BLOCK_EXPORT, CLASS_NAME_IDENT, DEFAULT_EXPORT } from "../../BlockSyntax";
@@ -6,17 +5,30 @@ import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
 import { sourceLocation } from "../../SourceLocation";
 
+import { BlockFactory } from "../index";
 import { parseBlockNames } from "../utils/blockNamesParser";
+
+const FROM_EXPR = /\s+from\s+/;
+
+/**
+ * Strip matching quotes from the beginning and end of a string
+ * @param str String to strip quotes from
+ * @return Result
+ */
+function stripQuotes(str: string): string {
+  return str.replace(/^(["'])(.+)\1$/, "$2");
+}
 
 /**
  * Resolve all block references for a given block.
  * @param block Block to resolve references for
  * @return Promise that resolves when all references have been loaded.
  */
-export async function exportBlocks(block: Block, file: string): Promise<Block> {
+export async function exportBlocks(block: Block, factory: BlockFactory, file: string): Promise<Block> {
 
   let root: postcss.Root | undefined = block.stylesheet;
-  let namedBlockReferences: Promise<[string, string, postcss.AtRule, Block]>[] = [];
+  const exportPromises: Promise<void>[] = [];
+  const remoteNames: Set<string> = new Set();
 
   if (!root) {
     throw new errors.InvalidBlockSyntax(`Error finding PostCSS root for block ${block.name}`);
@@ -27,75 +39,80 @@ export async function exportBlocks(block: Block, file: string): Promise<Block> {
 
   // For each `@block` expression, read in the block file, parse and
   // push to block references Promise array.
-  root.walkAtRules(BLOCK_EXPORT, (atRule: postcss.AtRule) => {
+  root.walkAtRules(BLOCK_EXPORT, async (atRule: postcss.AtRule) => {
     let exports = atRule.params;
 
-    if (!exports) {
+    let [exportList = "", blockPath = ""] = exports.split(FROM_EXPR);
+    blockPath = stripQuotes(blockPath);
+
+    if (!exportList) {
       throw new errors.InvalidBlockSyntax(
         `Malformed block export: \`@export ${atRule.params}\``,
         sourceLocation(file, atRule),
       );
     }
 
-    // Validate our imported block name is a valid CSS identifier.
-    let blockNames = parseBlockNames(exports, false);
-    for (let remoteName of Object.keys(blockNames)) {
-      let localName = blockNames[remoteName];
-      if (!CLASS_NAME_IDENT.test(localName)) {
-        throw new errors.InvalidBlockSyntax(
-          `Illegal block name in export. "${localName}" is not a legal CSS identifier.`,
-          sourceLocation(file, atRule),
-        );
-      }
-      if (!CLASS_NAME_IDENT.test(remoteName)) {
-        throw new errors.InvalidBlockSyntax(
-          `Illegal block name in import. "${remoteName}" is not a legal CSS identifier.`,
-          sourceLocation(file, atRule),
-        );
-      }
-      if (localName === DEFAULT_EXPORT && remoteName === DEFAULT_EXPORT) {
-        throw new errors.InvalidBlockSyntax(
-          `Unnecessary re-export of default Block.`,
-          sourceLocation(file, atRule),
-        );
-      }
-      if (remoteName === DEFAULT_EXPORT) {
-        throw new errors.InvalidBlockSyntax(
-          `Can not export "${localName}" as reserved word "${DEFAULT_EXPORT}"`,
-          sourceLocation(file, atRule),
-        );
-      }
-
-      let referencedBlock = block.getReferencedBlock(localName);
-      if (!referencedBlock) {
-        throw new errors.InvalidBlockSyntax(
-          `Can not export Block "${localName}". No Block named "${localName}" in "${file}".`,
-          sourceLocation(file, atRule),
-        );
-      }
-
-      // Save exported blocks
-      block.addBlockExport(remoteName, referencedBlock);
-
+    // Import file, then parse file, then save block reference.
+    let srcBlockPromise: Promise<Block> = Promise.resolve(block);
+    if (blockPath) {
+      srcBlockPromise = factory.getBlockRelative(block.identifier, blockPath);
     }
 
-  });
-
-  // When all import promises have resolved, save the block references and resolve.
-  return Promise.all(namedBlockReferences).then((results) => {
-    let localNames: ObjectDictionary<string> = {};
-    results.forEach(([localName, importPath, atRule, otherBlock]) => {
-      if (localNames[localName]) {
+    // Validate our imported block name is a valid CSS identifier.
+    const blockNames = parseBlockNames(exportList, !!blockPath);
+    const exportPromise = srcBlockPromise.then((srcBlock) => {
+      for (let remoteName of Object.keys(blockNames)) {
+        if (remoteNames.has(remoteName)) {
         throw new errors.InvalidBlockSyntax(
-          `Blocks ${localNames[localName]} and ${importPath} cannot both have the name ${localName} in this scope.`,
+          `Can not have duplicate Block export of same name: "${remoteName}".`,
           sourceLocation(file, atRule),
-        );
-      } else {
-        block.addBlockReference(localName, otherBlock);
-        localNames[localName] = importPath;
+          );
+        }
+        let localName = blockNames[remoteName];
+        console.log(remoteName, localName, block.identifier);
+        if (!CLASS_NAME_IDENT.test(localName)) {
+          throw new errors.InvalidBlockSyntax(
+            `Illegal block name in export. "${localName}" is not a legal CSS identifier.`,
+            sourceLocation(file, atRule),
+          );
+        }
+        if (!CLASS_NAME_IDENT.test(remoteName)) {
+          throw new errors.InvalidBlockSyntax(
+            `Illegal block name in import. "${remoteName}" is not a legal CSS identifier.`,
+            sourceLocation(file, atRule),
+          );
+        }
+        if (localName === DEFAULT_EXPORT && remoteName === DEFAULT_EXPORT) {
+          throw new errors.InvalidBlockSyntax(
+            `Unnecessary re-export of default Block.`,
+            sourceLocation(file, atRule),
+          );
+        }
+        if (remoteName === DEFAULT_EXPORT) {
+          throw new errors.InvalidBlockSyntax(
+            `Can not export "${localName}" as reserved word "${DEFAULT_EXPORT}"`,
+            sourceLocation(file, atRule),
+          );
+        }
+
+        let referencedBlock = srcBlock.getReferencedBlock(localName);
+        if (!referencedBlock) {
+          throw new errors.InvalidBlockSyntax(
+            `Can not export Block "${localName}". No Block named "${localName}" in "${file}".`,
+            sourceLocation(file, atRule),
+          );
+        }
+
+        // Save exported blocks
+        block.addBlockExport(remoteName, referencedBlock);
+
       }
     });
-  }).then(() => {
-    return block;
+
+    exportPromises.push(exportPromise);
+
   });
+
+  // After all export promises have resolved, resolve the decorated Block.
+  return Promise.all(exportPromises).then(() => block);
 }

--- a/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
@@ -19,7 +19,7 @@ export async function extendBlock(rule: postcss.Root, block: Block, sourceFile: 
     }
     let baseBlock = block.getReferencedBlock(decl.value);
     if (!baseBlock) {
-      throw new errors.InvalidBlockSyntax(`No block named ${decl.value} found`, sourceLocation(sourceFile, decl));
+      throw new errors.InvalidBlockSyntax(`No Block named "${decl.value}" found in scope.`, sourceLocation(sourceFile, decl));
     }
     block.setBase(baseBlock);
   });

--- a/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
@@ -18,7 +18,7 @@ export async function implementBlock(rule: postcss.Root, block: Block, sourceFil
     refNames.forEach((refName) => {
       let refBlock = block.getReferencedBlock(refName);
       if (!refBlock) {
-        throw new errors.InvalidBlockSyntax(`No block named ${refName} found`, sourceLocation(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`No Block named "${refName}" found in scope.`, sourceLocation(sourceFile, decl));
       }
       block.addImplementation(refBlock);
     });

--- a/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
@@ -26,7 +26,7 @@ export function parseBlockDebug(atRule: postcss.AtRule, sourceFile: string, scop
 
   if (!block) {
     throw new errors.InvalidBlockSyntax(
-      `Invalid block debug: No block named ${localName} exists in this context.`,
+      `Invalid block debug: No Block named "${localName}" found in scope.`,
       sourceLocation(sourceFile, atRule));
   }
 

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -12,7 +12,7 @@ import {
 
 import { isAttributeNode, isClassNode } from "../BlockParser";
 import { isRootNode, toAttrToken } from "../BlockParser";
-import { BlockPath, CLASS_NAME_IDENT, ROOT_CLASS } from "../BlockSyntax";
+import { BlockPath, CLASS_NAME_IDENT, DEFAULT_EXPORT, ROOT_CLASS } from "../BlockSyntax";
 import { ResolvedConfiguration } from "../configuration";
 import { CssBlockError, InvalidBlockSyntax } from "../errors";
 import { FileIdentifier } from "../importing";
@@ -249,7 +249,7 @@ export class Block
    * @returns Block | null.
    */
   getReferencedBlock(localName: string): Block | null {
-    if (localName === "") { return this; }
+    if (localName === "" || localName === DEFAULT_EXPORT) { return this; }
     return this._blockReferences[localName] || null;
   }
 

--- a/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
+++ b/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
@@ -7,12 +7,12 @@
  * `::after`). Every ruleset may provide resolution guidance against another `Style` object.
  */
 import { MultiMap, TwoKeyMultiMap } from "@opticss/util";
-import * as propParser from "css-property-parser";
 import { ParsedSelector, postcss } from "opticss";
 
 import { BLOCK_PROP_NAMES, SELF_SELECTOR, getResolution } from "../BlockSyntax";
 import { InvalidBlockSyntax } from "../errors";
 import { sourceLocation } from "../SourceLocation";
+import { expandProp } from "../util/propertyParser";
 
 import { Styles, isStyle } from "./Styles";
 export { Styles, BlockClass, AttrValue } from "./Styles";
@@ -31,25 +31,6 @@ export type Resolution<S extends Styles = Styles> = {
   property: string;
   resolution: S;
 };
-
-/**
- * Safely expand a property value pair into its constituent longhands,
- * even if it is not a valid declaration.
- * @param  property  A CSS property name.
- * @param  value  A CSS property value.
- */
-function expandProp(prop: string, value: string): propParser.Declarations {
-  let expanded: propParser.Declarations = {};
-
-  // The PropertyParser doesn't understand CSS variables.
-  // Replace them with something it understands.
-  value = value.replace(/var\([^\)]+\)/gi, "inherit");
-  if (propParser.isValidDeclaration(prop, value)) {
-    expanded = propParser.expandShorthandProperty(prop, value, true, false);
-  }
-  expanded[prop] = value;
-  return expanded;
-}
 
 /**
  * Represents an individual ruleset, its property concerns, and Style resolutions.

--- a/packages/@css-blocks/core/src/importing/NodeJsImporter.ts
+++ b/packages/@css-blocks/core/src/importing/NodeJsImporter.ts
@@ -68,7 +68,12 @@ export class NodeJsImporter implements Importer {
 
     // If no alias found, test for a node_module resolution as a file path.
     try {
-      return require.resolve(importPath, { paths: [config.rootDir] });
+      const file = require.resolve(importPath, { paths: [config.rootDir] });
+      const extname = path.extname(file).slice(1);
+      const fileExts = { css: true, ...config.preprocessors };
+      if (!fileExts[extname]) { throw Error("Invalid Block File Extension"); }
+      debug(`Discovered Node.js resolvable file: ${file}`);
+      return file;
     } catch (err) {
       debug(`Could not resolve ${importPath} as a local file. Resolution failed with ${err.message}.`);
     }

--- a/packages/@css-blocks/core/src/util/propertyParser.ts
+++ b/packages/@css-blocks/core/src/util/propertyParser.ts
@@ -1,0 +1,66 @@
+import * as propParser from "css-property-parser";
+
+import { isResolution } from "../BlockSyntax";
+
+const BORDER_SHORTHANDS = new Set(["border-top", "border-bottom", "border-left", "border-right"]);
+
+/**
+ * Safely expand a property value pair into its constituent longhands,
+ * even if it is not a valid declaration.
+ * @param  property  A CSS property name.
+ * @param  value  A CSS property value.
+ */
+export function expandProp(prop: string, value: string): propParser.Declarations {
+  let expanded: propParser.Declarations = {};
+
+  // PropertyParser bug causes infinite loop when parsing `font-family`.
+  // https://github.com/mahirshah/css-property-parser/issues/33
+  if (prop === "font-family") {
+    expanded[prop] = value;
+    return expanded;
+  }
+
+  // The PropertyParser doesn't understand resolve statements.
+  // Replace them with something it understands.
+  if (isResolution(value)) { value = "inherit"; }
+
+  // The PropertyParser doesn't understand CSS variables.
+  // Replace them with something it understands.
+  value = value.replace(/var\([^\)]+\)/gi, "inherit");
+
+  // The PropertyParser doesn't understand these intermediate border shorthands.
+  // Ducktape it together so it can.
+  let borderProp: string | null = null;
+  if (BORDER_SHORTHANDS.has(prop)) {
+    borderProp = prop;
+    prop = "border";
+  }
+
+  if (propParser.isValidDeclaration(prop, value)) {
+    expanded = propParser.expandShorthandProperty(prop, value, true, false);
+  }
+  expanded[prop] = value;
+
+  // Correct for intermediate border shorthands.
+  if (borderProp) {
+    expanded[borderProp] = value;
+    delete expanded["border"];
+    delete expanded["border-color"];
+    delete expanded["border-style"];
+    delete expanded["border-width"];
+    for (let bprop of BORDER_SHORTHANDS) {
+      if (bprop === borderProp) { continue; }
+      delete expanded[`${bprop}-color`];
+      delete expanded[`${bprop}-style`];
+      delete expanded[`${bprop}-width`];
+    }
+  }
+  else if (prop === "border") {
+    expanded["border-top"] = value;
+    expanded["border-left"] = value;
+    expanded["border-bottom"] = value;
+    expanded["border-right"] = value;
+  }
+
+  return expanded;
+}

--- a/packages/@css-blocks/core/test/block-inheritance-test.ts
+++ b/packages/@css-blocks/core/test/block-inheritance-test.ts
@@ -195,7 +195,9 @@ export class BlockInheritance extends BEMProcessor {
         result.css.toString(),
         ".sub__nav { margin: 15px; }\n" +
         ".base__nav.sub__nav { margin: 15px; }\n" +
+        ".base__nav + .base__nav.sub__nav { margin: 15px; }\n" +
         ".sub__nav + .sub__nav { margin-bottom: 5px; }\n" +
+        ".sub__nav + .base__nav.sub__nav { margin-bottom: 5px; }\n" +
         ".base__nav.sub__nav + .base__nav.sub__nav { margin-bottom: 5px; }\n",
       );
     });

--- a/packages/@css-blocks/core/test/resolution-test.ts
+++ b/packages/@css-blocks/core/test/resolution-test.ts
@@ -219,7 +219,6 @@ export class BlockInheritance extends BEMProcessor {
     });
   }
 
-  @skip
   @test "of short-hand properties conflicting with long-hand properties"() {
     let { imports, config } = setupImporting();
     imports.registerSource(
@@ -256,11 +255,11 @@ export class BlockInheritance extends BEMProcessor {
       assert.deepEqual(
         result.css.toString(),
         ".conflicts__header { border-bottom: 2px; }\n" +
-        ".conflicts__header.grid__nav { border-bottom: 1px solid black }\n" +
+        ".grid__nav.conflicts__header { border-bottom: 1px solid black; }\n" +
         ".conflicts__another-header { border-width: 3px; }\n" +
-        ".conflicts__another-header.grid__nav { border-width: 1px; }\n" +
+        ".grid__nav.conflicts__another-header { border-width: 1px; }\n" +
         ".conflicts__third-header { border-bottom-width: 3px; }\n" +
-        ".conflicts__third-header.grid__nav { border-bottom-width: 1px; }\n",
+        ".grid__nav.conflicts__third-header { border-bottom-width: 1px; }\n",
       );
     });
   }
@@ -378,7 +377,7 @@ export class BlockInheritance extends BEMProcessor {
       "other.css",
       `@block base from "base.css";
        :scope { extends: base; }
-       .nav { border: 1px solid black; color: red; }`,
+       .nav { border: 1px solid green; color: red; }`,
     );
 
     let filename = "conflicts.css";
@@ -399,7 +398,7 @@ export class BlockInheritance extends BEMProcessor {
         result.css.toString(),
         ".conflicts__header { width: 80%; border: none; color: green; }\n" +
         ".base__sidebar.conflicts__header { color: blue; }\n" +
-        ".other__nav.conflicts__header { border: 1px solid black; }\n" +
+        ".other__nav.conflicts__header { border: 1px solid green; }\n" +
         ".base__nav.conflicts__header { width: 100%; }\n",
       );
     });


### PR DESCRIPTION
 - ConflictResolver now takes shorthands into consideration.
 - PropertyParser has special cases for border and font-family because of bugs in source package.
 - fix: Export syntax now allows for immediate re-export from file path.
 - Added more debug statements.
 - Fix Broccoli bug to only remove files from tmp directory output.