### PR TITLE
feat: Binary runtime helper.

### DIFF
--- a/packages/@css-blocks/runtime/src/ExpressionContainer.ts
+++ b/packages/@css-blocks/runtime/src/ExpressionContainer.ts
@@ -1,11 +1,17 @@
 import { OP_CODE, runtime } from "./runtime";
 
+// Convenience re-exports for ergonomic APIs (see test file).
+export const OR  = OP_CODE.OR;
+export const AND = OP_CODE.AND;
+export const EQ  = OP_CODE.EQUAL;
+export const NOT = (val: Value | Expression) => ({ val, not: true });
+
 // Maps OP_CODE values to human readable strings.
 const OP_STR = {
-  0: "OR",
-  1: "AND",
-  2: "EQ",
-  3: "SEP",
+  [OR]: "OR",
+  [AND]: "AND",
+  [EQ]: "EQ",
+  [OP_CODE.SEP]: "SEP",
 };
 
 // The index of an input value to be resolved at runtime.
@@ -55,12 +61,6 @@ export interface Flattened {
   expressions: SimpleExpression[];
   indices: Map<string, number>;
 }
-
-// Convenience re-exports for ergonomic APIs (see test file).
-export const OR  = OP_CODE.OR;
-export const AND = OP_CODE.AND;
-export const EQ  = OP_CODE.EQUAL;
-export const NOT = (val: Value | Expression) => ({ val, not: true });
 
 /**
  * Given a left operand, opcode, and right expression, return an expression object.

--- a/packages/@css-blocks/runtime/src/ExpressionContainer.ts
+++ b/packages/@css-blocks/runtime/src/ExpressionContainer.ts
@@ -9,7 +9,6 @@ export const EQ  = OP_CODE.EQUAL;
 // there's only two bits at runtime.
 const NOT_OP: 4 = 4;
 
-
 // Maps OP_CODE values to human readable strings.
 const OP_STR = {
   [OR]: "OR",

--- a/packages/@css-blocks/runtime/src/ExpressionContainer.ts
+++ b/packages/@css-blocks/runtime/src/ExpressionContainer.ts
@@ -19,7 +19,9 @@ const OP_STR = {
   [OP_CODE.SEP]: "SEP",
 };
 
-// The index of an input value to be resolved at runtime.
+/**
+ * The index of an input value to be resolved at runtime.
+ **/
 export type Value = number;
 type UID = number;
 
@@ -55,7 +57,9 @@ export interface Expression {
   notRight: boolean;
 }
 
-// Valid operand values for our expr() function.
+/**
+ * Valid operand values for our expr() function.
+ **/
 export type Operand = Value | Expression | NotValue;
 
 /**

--- a/packages/@css-blocks/runtime/src/ExpressionContainer.ts
+++ b/packages/@css-blocks/runtime/src/ExpressionContainer.ts
@@ -1,137 +1,231 @@
-import { runtime } from "./runtime";
+import { OP_CODE, runtime } from "./runtime";
 
-export const enum OP_CODE {
-  CLOSE  = "000",
-  OPEN   = "001",
-  VAL    = "010",
-  NOT    = "011",
-  OR     = "100",
-  AND    = "101",
-  EQUAL  = "110",
-  CONCAT = "111",
+// Maps OP_CODE values to human readable strings.
+const OP_STR = {
+  0: "OR",
+  1: "AND",
+  2: "EQ",
+  3: "SEP",
+};
+
+// The index of an input value to be resolved at runtime.
+export type Value = number;
+
+// Represents the inversion of a resolved or computed value.
+export interface NotValue {
+  val: Value | Expression;
+  not: boolean;
 }
 
-// The maximum safe number of opcodes we're able to encode in a single 32 bit integer
-// However! When converting from base36 and back again, leading zeros are stripped. To
-// fix this, we prefix every shape with a throwaway bit at the beginning, so the actual
-// safe number is 31.
-const MAX_SAFE_BITS = 31;
+/**
+ * Determine if a provided value is a `NotValue` interface.
+ * @param v Any value.
+ */
+function isNotValue(v: unknown): v is NotValue { return v && (v as NotValue).hasOwnProperty("val") && (v as NotValue).hasOwnProperty("not"); }
 
-// Converts a string of opcodes to a Base2 encoded string with leading `1` to pad significant 0's
-const toBase2 = (str: string) => `1${str.split("").reverse().join("")}`;
+/**
+ * Represents a single node in a boolean expression binary tree.
+ */
+export interface Expression {
+  left: Expression | Value;
+  notLeft: boolean;
+  op: OP_CODE;
+  right: Expression | Value;
+  notRight: boolean;
+}
 
-// Convert a string of 1's and 0's to a Base36 encoded string.
-const toBase36 = (str: string) => parseInt(toBase2(str), 2).toString(36);
+// Valid operand values for our expr() function.
+export type Operand = Value | Expression | NotValue;
 
-export class ExpressionContainer<T = unknown> {
-  public ops: string[] = [];
-  private classes: string[] = [];
-  private exprs: T[] = [];
-  private exprIdx: Map<T, number> = new Map();
+/**
+ * SimpleExpression objects are a special representation of Expressions
+ * that will only reference resolved values at runtime. They are completely flat.
+ */
+export interface SimpleExpression extends Expression {
+  left: Value;
+  right: Value;
+}
 
-  // The bit size of value encodings is dependent on the number of value
-  // indices we need to keep track of.
-  private valSize() { return ~~Math.log2(this.exprs.length - 1) + 1; }
+/**
+ * The flattened representation of an Expression binary tree.
+ * This is converted basically 1:1 to the binary runtime shapes.
+ */
+export interface Flattened {
+  arguments: Set<number>;
+  expressions: SimpleExpression[];
+  indices: Map<string, number>;
+}
 
-  // Track a value, referenced by index.
-  val(expr: T) {
-    this.ops.push(OP_CODE.VAL);
-    let idx = this.exprIdx.get(expr);
-    if (idx === undefined) {
-      idx = this.exprs.length;
-      this.exprIdx.set(expr, idx);
-      this.exprs.push(expr);
-    }
-    this.ops.push(idx.toString(2));
+// Convenience re-exports for ergonomic APIs (see test file).
+export const OR  = OP_CODE.OR;
+export const AND = OP_CODE.AND;
+export const EQ  = OP_CODE.EQUAL;
+export const NOT = (val: Value | Expression) => ({ val, not: true });
+
+/**
+ * Given a left operand, opcode, and right expression, return an expression object.
+ * Left and right operands may be the index of an input value, a `NotValue` expression,
+ * or another Expression object, making this a very fancy binary tree.
+ * @param left The Left Operand
+ * @param op OP_CODE to process left and right with
+ * @param right The Right Operand.
+ */
+export function expr(left: Operand, op: OP_CODE, right: Operand): Expression {
+  let notLeft = false;
+  let notRight = false;
+  if (isNotValue(left)) {
+    notLeft = left.not;
+    left = left.val;
+  }
+  if (isNotValue(right)) {
+    notRight = right.not;
+    right = right.val;
+  }
+  return { left, op, right, notLeft, notRight };
+}
+
+/**
+ * Generate a string UID for any SimpleExpression.
+ * @param expr The SimpleExpression we're generating a UID for.
+ */
+function genUid(expr: SimpleExpression): string {
+  return `VAR ${expr.notLeft ? "!" : ""}${expr.left} ${OP_STR[expr.op]} VAR ${expr.notRight ? "!" : ""}${expr.right}`;
+}
+
+/**
+ * Discover all `Value`s referenced in a boolean Expression tree.
+ * @param expr The Expression tree to crawl.
+ * @param out The Flattened output object to read values in to.
+ */
+function getArgs(expr: Expression, out: Flattened) {
+  if (typeof expr.left === "number") { out.arguments.add(expr.left); }
+  else { getArgs(expr.left, out); }
+
+  if (typeof expr.right === "number") { out.arguments.add(expr.right); }
+  else { getArgs(expr.right, out); }
+}
+
+/**
+ * Provided an Expression binary tree, read all values in to the Flattened data object.
+ * @param expr The Expression tree to crawl.
+ * @param out The Flattened object to read data in to.
+ */
+function visit(expr: Expression, out: Flattened): number {
+
+  // Convert this expression to a SimpleExpression
+  let simpleExpr: SimpleExpression = {
+    left: (typeof expr.left  !== "number") ? visit(expr.left, out) : expr.left,
+    right: (typeof expr.right  !== "number") ? visit(expr.right, out) : expr.right,
+    op: expr.op,
+    notLeft: expr.notLeft,
+    notRight: expr.notRight,
+  };
+
+  // Generate a UID for this expression.
+  let uid = genUid(simpleExpr);
+
+  // Save this expression in the simple expressions array, if an equivalent expression is not there.
+  if (!out.indices.has(uid)) {
+    out.expressions.push(simpleExpr);
+    out.indices.set(uid, out.expressions.length - 1);
+  }
+
+  // Return the expression's index reference.
+  return out.indices.get(uid)! + out.arguments.size;
+}
+
+/**
+ * Flatten an ExpressionContainer object, reading values in to a Flattened data structure.
+ * @param el The ExpressionContainer to flatten.
+ */
+function flattenExpressions(el: ExpressionContainer): Flattened {
+  const out: Flattened = {
+    arguments: new Set(),
+    expressions: [],
+    indices: new Map(),
+  };
+
+  // Fetch all referenced args.
+  el.forEachClass((_c, e) => getArgs(e, out));
+
+  // For every root note, crawl its descendents and populate the Flattened object
+  // with the used expressions.
+  const classExprs = el.getExprs().map((expr): SimpleExpression => ({
+    left: (typeof expr.left  !== "number") ? visit(expr.left, out) : expr.left,
+    right: (typeof expr.right  !== "number") ? visit(expr.right, out) : expr.right,
+    op: expr.op,
+    notLeft: expr.notLeft,
+    notRight: expr.notRight,
+  }));
+
+  // Ensure all classExpr root nodes are at the end of the Flattened expression list.
+  out.expressions = [...out.expressions, ...classExprs];
+
+  return out;
+}
+
+export class ExpressionContainer {
+
+  private classes: {[key: string]: Expression} = {};
+
+  /**
+   * Add a new class to this ExpressionContainer.
+   * @param name The class name we're determining presence for.
+   * @param expr The Expression that evaluates to true or false, representing class application.
+   */
+  class(name: string, expr: Expression) { this.classes[name] = expr; }
+
+  /**
+   * Iterate over all classes stored on this ExpressionContainer.
+   * @param cb forEachClass callback function. Passed the class name, and Expression.
+   */
+  forEachClass(cb: (c: string, e: Expression) => void): ExpressionContainer {
+    for (let key of Object.keys(this.classes)) { cb(key, this.classes[key]); }
     return this;
   }
 
-  // `when()` is a proxy for `val()` for better english-language-like constructor chains.
-  when(expr: T) { return this.val(expr); }
+  // Expression and Class introspection methods.
+  getExprs(): Expression[] { return Object.values(this.classes); }
+  getClasses(): string[]   { return Object.keys(this.classes);   }
 
-  // The start of an expression. Apply this class when the following
-  // expression evaluates to true for a given input.
-  apply(klass: string)  {
-    this.classes.push(klass);
-    if (this.ops.length) { this.ops.push(OP_CODE.CONCAT); }
-    return this;
-  }
-
-  // Operands
-  get not()     { this.ops.push(OP_CODE.NOT); return this;   }
-  get open()    { this.ops.push(OP_CODE.OPEN); return this;  }
-  get or()      { this.ops.push(OP_CODE.OR); return this;    }
-  get and()     { this.ops.push(OP_CODE.AND); return this;   }
-  get equals()  { this.ops.push(OP_CODE.EQUAL); return this; }
-  get close()   { this.ops.push(OP_CODE.CLOSE); return this; }
-
-  // Introspection methods.
-  getExprs(): T[] { return this.exprs.slice(0); }
-  getClasses(): string[] { return this.classes.slice(0); }
-  getOps(): string[] { return this.ops.slice(); }
-
-  getBinaryString(): string[] {
-    const out = [];
-    let valSize = this.valSize();
-    let working = "";
-    let isVal = false;
-    for (let op of this.ops) {
-
-      // If this opcode is a VAL (preceded by VAL opcode) ensure its binary
-      // value is padded to be the valSize length.
-      if (isVal) {
-        op = "0".repeat(Math.max(valSize - op.length , 0)) + op;
-        isVal = false;
-      }
-
-      // If this opcode is a VAL, consume the next op as a value.
-      isVal = op === OP_CODE.VAL;
-
-      // If this opcode would overflow the MAX_SAVE_INTEGER when converted to
-      // an integer, strike a new base36 string.
-      if (working.length + op.length >= MAX_SAFE_BITS) {
-        out.push(toBase2(working));
-        working = "";
-      }
-
-      working += op;
+  /**
+   * Get the binary string (ex: "1001001001010") that represents all the registered classes'
+   * application logic in this ExpressionContainer.
+   */
+  getBinaryString(): string {
+    const flattened = flattenExpressions(this);
+    const argCount = flattened.arguments.size;
+    const classesCount = Object.keys(this.classes).length;
+    let exprCount = 0;
+    let out = "";
+    for (let idx = 0; idx < flattened.expressions.length; idx++) {
+      let expr = flattened.expressions[idx];
+      let isSep = (flattened.expressions.length - classesCount) === idx;
+      let size = ~~Math.log2(exprCount + argCount - 1) + 1;
+      let left  = expr.left.toString(2).padStart(size, "0") + (expr.notLeft ? "1" : "0");
+      let op    = expr.op.toString(2).padStart(2, "0");
+      let right = expr.right.toString(2).padStart(size, "0") + (expr.notRight ? "1" : "0");
+      out += (isSep ? OP_CODE.SEP.toString(2) : "") + op + left + right;
+      exprCount++;
+      // console.log(`${genUid(expr)}:`, op, left, right);
     }
 
-    if (working) { out.push(toBase2(working)); }
     return out;
   }
 
-  // Calculate the binary string encoding of this expression's logic shape.
+  /**
+   * Calculate the base36 binary string encoding of this expression's logic shape.
+   */
   getBinaryEncoding(): string[] {
-    const out = [];
-    let valSize = this.valSize();
-    let working = "";
-    let isVal = false;
-    for (let op of this.ops) {
-
-      // If this opcode is a VAL (preceded by VAL opcode) ensure its binary
-      // value is padded to be the valSize length.
-      if (isVal) {
-        op = "0".repeat(Math.max(valSize - op.length , 0)) + op;
-        isVal = false;
-      }
-
-      // If this opcode is a VAL, consume the next op as a value.
-      isVal = op === OP_CODE.VAL;
-
-      // If this opcode would overflow the MAX_SAVE_INTEGER when converted to
-      // an integer, strike a new base36 string.
-      if (working.length + op.length >= MAX_SAFE_BITS) {
-        out.push(toBase36(working));
-        working = "";
-      }
-      working += op;
-    }
-    if (working) { out.push(toBase36(working)); }
-    return out;
+    return this.getBinaryString().match(/.{1,32}/g)!.map((s) => parseInt(s.split("").reverse().join(""), 2).toString(36));
   }
 
-  exec(...args: T[]) {
+  /**
+   * Convenience method to test class application. Calls the binary runtime using
+   * the binary encoded expression shapes and provided arguments.
+   * @param args Arguments to evaluate this expression using.
+   */
+  exec(...args: unknown[]) {
     return runtime(this.getBinaryEncoding(), this.getClasses(), args);
   }
 }

--- a/packages/@css-blocks/runtime/src/constructor.ts
+++ b/packages/@css-blocks/runtime/src/constructor.ts
@@ -1,0 +1,102 @@
+export type whatever = string | number | boolean | symbol | object | null | undefined | void;
+
+export const enum OP_CODE {
+  OPEN   = "000",
+  VAL    = "001",
+  NOT    = "010",
+  OR     = "011",
+  AND    = "100",
+  EQUAL  = "101",
+  CLOSE  = "110",
+  CONCAT = "111",
+}
+
+// The maximum safe number of opcodes we're able to encode in a single base 36 string.
+// The maximum number of binary digits we're allowed in a number in Javascript is 53:
+// Number.MAX_SAFE_INTEGER.toString(2).length === 53.
+// However! When converting from base36 and back again, leading zeros are stripped. To
+// fix this, we prefix every shape with a throwaway bit at the beginning, so the actual
+// safe number is 52.
+const MAX_SAFE_OPCODES = 52;
+
+export class Expression {
+  public ops: string[] = [];
+  private classes: string[] = [];
+  private exprs: whatever[] = [];
+  private exprIdx: Map<whatever, number> = new Map();
+
+  // The bit size of value encodings is dependent on the number of value
+  // indices we need to keep track of.
+  private valSize() { return ~~Math.log2(this.exprs.length - 1) + 1; }
+
+  // Track a value, referenced by index.
+  val(expr: whatever) {
+    this.ops.push(OP_CODE.VAL);
+    let idx = this.exprIdx.get(expr);
+    if (idx === undefined) {
+      idx = this.exprs.length;
+      this.exprIdx.set(expr, idx);
+      this.exprs.push(expr);
+    }
+    this.ops.push(idx.toString(2));
+    return this;
+  }
+
+  // `when()` is a proxy for `val()` for better english-language-like constructor chains.
+  when(expr: whatever) { return this.val(expr); }
+
+  // Track an inverse value.
+  not(expr: whatever) {
+    this.ops.push(OP_CODE.NOT);
+    return this.val(expr);
+  }
+
+  // The start of an expression. Apply this class when the following
+  // expression evaluates to true for a given input.
+  apply(klass: string)  {
+    this.classes.push(klass);
+    if (this.ops.length) { this.ops.push(OP_CODE.CONCAT); }
+    return this;
+  }
+
+  // Operands
+  get open()    { this.ops.push(OP_CODE.OPEN); return this;  }
+  get or()      { this.ops.push(OP_CODE.OR); return this;    }
+  get and()     { this.ops.push(OP_CODE.AND); return this;   }
+  get equals()  { this.ops.push(OP_CODE.EQUAL); return this; }
+  get close()   { this.ops.push(OP_CODE.CLOSE); return this; }
+
+  // Introspection methods.
+  getExprs(): whatever[] { return this.exprs.slice(0); }
+  getClasses(): string[] { return this.classes.slice(0); }
+  getOps(): string[] { return this.ops.slice(); }
+
+  // Calculate the binary string encoding of this expression's logic shape.
+  getShape(): string[] {
+    const OUT = [];
+    let working = "";
+    let isVal = false;
+    for (let op of this.ops) {
+
+      // If this opcode is a VAL (preceded by VAL opcode) ensure its binary
+      // value is padded to be the valSize length.
+      if (isVal) {
+        op = "0".repeat(Math.max(this.valSize() - op.length , 0)) + op;
+        isVal = false;
+      }
+
+      // If this opcode is a VAL, consume the next op as a value.
+      isVal = op === OP_CODE.VAL;
+
+      // If this opcode would overflow the MAX_SAVE_INTEGER when converted to
+      // an integer, strike a new base36 string.
+      if (working.length + op.length >= MAX_SAFE_OPCODES) {
+        OUT.push(parseInt(`1${working.split("").reverse().join("")}`, 2).toString(36));
+        working = "";
+      }
+      working += op;
+    }
+    if (working) { OUT.push(parseInt(`1${working.split("").reverse().join("")}`, 2).toString(36)); }
+    return OUT;
+  }
+}

--- a/packages/@css-blocks/runtime/src/constructor.ts
+++ b/packages/@css-blocks/runtime/src/constructor.ts
@@ -1,36 +1,32 @@
-export type whatever = string | number | boolean | symbol | object | null | undefined | void;
-
 export const enum OP_CODE {
-  OPEN   = "000",
-  VAL    = "001",
-  NOT    = "010",
-  OR     = "011",
-  AND    = "100",
-  EQUAL  = "101",
-  CLOSE  = "110",
+  CLOSE  = "000",
+  OPEN   = "001",
+  VAL    = "010",
+  NOT    = "011",
+  OR     = "100",
+  AND    = "101",
+  EQUAL  = "110",
   CONCAT = "111",
 }
 
-// The maximum safe number of opcodes we're able to encode in a single base 36 string.
-// The maximum number of binary digits we're allowed in a number in Javascript is 53:
-// Number.MAX_SAFE_INTEGER.toString(2).length === 53.
+// The maximum safe number of opcodes we're able to encode in a single 32 bit integer
 // However! When converting from base36 and back again, leading zeros are stripped. To
 // fix this, we prefix every shape with a throwaway bit at the beginning, so the actual
-// safe number is 52.
-const MAX_SAFE_OPCODES = 52;
+// safe number is 31.
+const MAX_SAFE_BITS = 31;
 
 export class Expression {
   public ops: string[] = [];
   private classes: string[] = [];
-  private exprs: whatever[] = [];
-  private exprIdx: Map<whatever, number> = new Map();
+  private exprs: unknown[] = [];
+  private exprIdx: Map<unknown, number> = new Map();
 
   // The bit size of value encodings is dependent on the number of value
   // indices we need to keep track of.
   private valSize() { return ~~Math.log2(this.exprs.length - 1) + 1; }
 
   // Track a value, referenced by index.
-  val(expr: whatever) {
+  val(expr: unknown) {
     this.ops.push(OP_CODE.VAL);
     let idx = this.exprIdx.get(expr);
     if (idx === undefined) {
@@ -43,13 +39,7 @@ export class Expression {
   }
 
   // `when()` is a proxy for `val()` for better english-language-like constructor chains.
-  when(expr: whatever) { return this.val(expr); }
-
-  // Track an inverse value.
-  not(expr: whatever) {
-    this.ops.push(OP_CODE.NOT);
-    return this.val(expr);
-  }
+  when(expr: unknown) { return this.val(expr); }
 
   // The start of an expression. Apply this class when the following
   // expression evaluates to true for a given input.
@@ -60,6 +50,7 @@ export class Expression {
   }
 
   // Operands
+  get not()     { this.ops.push(OP_CODE.NOT); return this;   }
   get open()    { this.ops.push(OP_CODE.OPEN); return this;  }
   get or()      { this.ops.push(OP_CODE.OR); return this;    }
   get and()     { this.ops.push(OP_CODE.AND); return this;   }
@@ -67,9 +58,37 @@ export class Expression {
   get close()   { this.ops.push(OP_CODE.CLOSE); return this; }
 
   // Introspection methods.
-  getExprs(): whatever[] { return this.exprs.slice(0); }
+  getExprs(): unknown[] { return this.exprs.slice(0); }
   getClasses(): string[] { return this.classes.slice(0); }
   getOps(): string[] { return this.ops.slice(); }
+
+  getBinary(): string[] {
+    const OUT = [];
+    let working = "";
+    let isVal = false;
+    for (let op of this.ops) {
+
+      // If this opcode is a VAL (preceded by VAL opcode) ensure its binary
+      // value is padded to be the valSize length.
+      if (isVal) {
+        op = "0".repeat(Math.max(this.valSize() - op.length , 0)) + op;
+        isVal = false;
+      }
+
+      // If this opcode is a VAL, consume the next op as a value.
+      isVal = op === OP_CODE.VAL;
+
+      // If this opcode would overflow the MAX_SAVE_INTEGER when converted to
+      // an integer, strike a new base36 string.
+      if (working.length + op.length >= MAX_SAFE_BITS) {
+        OUT.push(parseInt(`1${working.split("").reverse().join("")}`, 2).toString(36));
+        working = "";
+      }
+
+      working += op;
+    }
+    return OUT;
+  }
 
   // Calculate the binary string encoding of this expression's logic shape.
   getShape(): string[] {
@@ -90,7 +109,7 @@ export class Expression {
 
       // If this opcode would overflow the MAX_SAVE_INTEGER when converted to
       // an integer, strike a new base36 string.
-      if (working.length + op.length >= MAX_SAFE_OPCODES) {
+      if (working.length + op.length >= MAX_SAFE_BITS) {
         OUT.push(parseInt(`1${working.split("").reverse().join("")}`, 2).toString(36));
         working = "";
       }

--- a/packages/@css-blocks/runtime/src/runtime.ts
+++ b/packages/@css-blocks/runtime/src/runtime.ts
@@ -2,7 +2,7 @@ type Invert = true | null;
 type Op     = number | null;
 type Value  = boolean | null;
 
-export const enum OP_CODE {
+const enum OP_CODE {
   CLOSE  = 0,
   OPEN   = 1,
   VAL    = 2,
@@ -18,27 +18,28 @@ export function runtime(shape: string[], classes: string[], exprs: unknown[]): s
   // We dynamically determine the variable window size based on the number of
   // expressions it is possible to reference. It is the compiler's responsibility
   // to guarantee the expression shape matches at build time.
-  const VAR_SIZE = ~~Math.log2(exprs.length - 1) + 1;
+  const NULL = (shape && null); // Minifier hax to save bytes.
+  const VAR_SIZE = ~~Math.log2(exprs.length - 1) + 1; // Variable token size is dependant on the number of dynamic values passed.
   const stack: [Op, Value, Invert][]    = []; // Stack for nested boolean expressions
 
   let out   = "";    // Output class list.
   let klass = 0;     // Current class we are determining presence for.
-  let current: Op    = null;  // Current discovered opcode to evaluate.
-  let val: Value     = null;  // Working boolean expression value.
-  let op: Op         = null;  // Operation to evaluate on next val discovered.
-  let invert: Invert = null;  // Should we invert the next discovered value.
+  let current: Op    = NULL;  // Current discovered opcode to evaluate.
+  let val: Value     = NULL;  // Working boolean expression value.
+  let op: Op         = NULL;  // Operation to evaluate on next val discovered.
+  let invert: Invert = NULL;  // Should we invert the next discovered value.
 
   // For each 32 bit integer passed to us as a base 36 string
   for ( let segment of shape ) {
 
-    let integer = parseInt(segment, 36); // Convert binary string segment to a base 10 integer
-    let step  = 0;     // Character count used for opcode discovery.
-    let next  = 0;     // This is a single lookahead parser – next opcode will be stored here.
+    let tmp: Value = NULL; // Stores the right side of a boolean operation.
+    let step  = 0;         // Character count used for opcode discovery.
+    let next  = 0;         // This is a single lookahead parser – next opcode will be stored here.
+    let integer = parseInt(segment, 36);    // Convert binary string segment to a base 10 integer
+    let iters = integer.toString(2).length; // Process each bit in this integer, minus the first `1` inserted for significant bit padding.
 
-    // Process each bit in this integer, minus the first `1` inserted for significant bit padding.
     // Note: `while` loop is faster than a `for` loop here.
-    let iters = integer.toString(2).length;
-    main: while (iters--) {
+    while (iters--) {
 
       // Construct our lookahead opcode and "pop" a bit off the end
       // of our integer's binary representation.
@@ -46,33 +47,33 @@ export function runtime(shape: string[], classes: string[], exprs: unknown[]): s
       next += integer % 2 * (2 * (size - 1 - step) || 1); // tslint:disable-line
       integer = integer >>> 1;                            // tslint:disable-line
 
-      // When we have discovered the next opcode, process.
-      if (iters === 0 || !(step = ++step % size)) {
-        let tmp: Value = null;
+      // When we have discovered the next opcode, or are on the last opcode, process.
+      if (!iters || !(step = ++step % size)) {
+
+        // tslint:disable:switch-default
         switch (current) {
 
           // If no current op-code, move on.
-          case null: break;
+          case NULL: break;
 
-          // OPEN
+          // OPEN – Push state to stack and start fresh.
           case OP_CODE.OPEN:
             stack.push([op, val, invert]);
-            val = invert = op = null;
+            val = invert = op = NULL;
             break;
 
-          // VAL: `010`
-          // CLOSE: `000`
+          // VAL or CLOSE (fun fact: functionally the same thing!)
           case OP_CODE.CLOSE:
-            if (!stack.length) break main; // If we've hit a close with no stack, we're done.
-            tmp = val;
+            tmp = val; // Save computed val.
             [ op, val, invert] = stack.pop()!;
             // Intentionally no break. Falls through to VAL evaluation.
 
           case OP_CODE.VAL:
-            if (current !== OP_CODE.CLOSE) tmp = !!exprs[next];
+            if (current !== OP_CODE.CLOSE) tmp = !!exprs[next]; // Save referenced val.
 
-            tmp = invert ? !tmp : tmp;
+            tmp = invert ? !tmp : tmp; // Invert value if required.
 
+            // Process boolean expression if requested. If no opcode, this is the left side value.
             switch (op) {
               case OP_CODE.OR:    val = val || tmp; break;
               case OP_CODE.AND:   val = val && tmp; break;
@@ -80,39 +81,37 @@ export function runtime(shape: string[], classes: string[], exprs: unknown[]): s
               default: val = tmp;
             }
 
-            invert = op = null;
+            // Reset state. This is safe to do at all types here. Saves bytes.
+            invert = op = NULL;
             break;
 
-          // NOT: `010`
+          // NOT – Save if we should invert the next value discovered.
           case OP_CODE.NOT: invert = true; break;
 
-          // OR: `011`
-          // AND: `100`
-          // EQUAL: `101`
+          // OR | AND | EQUAL – Save opcode value.
           case OP_CODE.OR:
           case OP_CODE.AND:
           case OP_CODE.EQUAL:
             op = current;
             break;
 
-          // CONCAT: `111`
+          // CONCAT – Apply class if `val` is truthy and reset state.
           case OP_CODE.CONCAT:
             out += val ? (out ? " " : "") + classes[klass] : "";
             klass++;
-            op = invert = val = null;
+            op = invert = val = NULL;
             break;
-
-          // If op-code is unrecognized, throw.
-          default: throw new Error("Unknown CSS Blocks op-code.");
         }
 
-        // Begin construction of next opcode. Skip `val` indices.
-        current = (current === OP_CODE.VAL) ? null : next;
+        // Begin construction of next opcode. Skip processing`val` index tokens.
+        current = (current === OP_CODE.VAL) ? NULL : next;
         next = 0;
       }
     }
   }
 
+  // End of expression does not require a CONCAT opcode.
+  // Apply final class if `val` is truthy.
   out += val ? (out ? " " : "") + classes[klass] : "";
   return out;
 }

--- a/packages/@css-blocks/runtime/src/runtime.ts
+++ b/packages/@css-blocks/runtime/src/runtime.ts
@@ -1,83 +1,105 @@
-export type whatever = string | number | boolean | symbol | object | null | undefined | void;
+type Invert = true | null;
+type Op     = number | null;
+type Value  = boolean | null;
 
-export function runtime(shape: string[], classes: string[], exprs: whatever[]): string {
+export const enum OP_CODE {
+  CLOSE  = 0,
+  OPEN   = 1,
+  VAL    = 2,
+  NOT    = 3,
+  OR     = 4,
+  AND    = 5,
+  EQUAL  = 6,
+  CONCAT = 7,
+}
+
+export function runtime(shape: string[], classes: string[], exprs: unknown[]): string {
 
   // We dynamically determine the variable window size based on the number of
   // expressions it is possible to reference. It is the compiler's responsibility
   // to guarantee the expression shape matches at build time.
   const VAR_SIZE = ~~Math.log2(exprs.length - 1) + 1;
+  const stack: [Op, Value, Invert][]    = []; // Stack for nested boolean expressions
 
-  let out     = "";    // Output class list.
-  let klass   = 0;     // Current class we are determining presence for.
-  let val     = null;  // Working boolean expression value.
-  let step    = 0;     // Character count used for opcode discovery.
-  let current = null;  // Current discovered opcode to evaluate.
-  let next    = 0;     // This is a single lookahead parser – next opcode will be stored here.
-  let op      = null;  // Operation to evaluate on next val discovered.
-  let invert  = false; // Should we invert the next discovered value.
-  // let stack    = []; // Stack for nested boolean expressions
+  let out   = "";    // Output class list.
+  let klass = 0;     // Current class we are determining presence for.
+  let current: Op    = null;  // Current discovered opcode to evaluate.
+  let val: Value     = null;  // Working boolean expression value.
+  let op: Op         = null;  // Operation to evaluate on next val discovered.
+  let invert: Invert = null;  // Should we invert the next discovered value.
 
   // For each 32 bit integer passed to us as a base 36 string
   for ( let segment of shape ) {
 
-    // Convert binary string segment to a base 10 integer
-    let integer = parseInt(segment, 36);
+    let integer = parseInt(segment, 36); // Convert binary string segment to a base 10 integer
+    let step  = 0;     // Character count used for opcode discovery.
+    let next  = 0;     // This is a single lookahead parser – next opcode will be stored here.
 
-    // Process each bit in this 32 bit integer.
+    // Process each bit in this integer, minus the first `1` inserted for significant bit padding.
     // Note: `while` loop is faster than a `for` loop here.
-    let iters = 32;
-    while (iters--) {
+    let iters = integer.toString(2).length;
+    main: while (iters--) {
 
       // Construct our lookahead opcode and "pop" a bit off the end
       // of our integer's binary representation.
-      let size = (current === 1 ? VAR_SIZE : 3);
+      let size = (current === OP_CODE.VAL ? VAR_SIZE : 3);
       next += integer % 2 * (2 * (size - 1 - step) || 1); // tslint:disable-line
       integer = integer >>> 1;                            // tslint:disable-line
 
       // When we have discovered the next opcode, process.
-      if (!(step = ++step % size)) {
-
-        // Each opcode type requires implementation
+      if (iters === 0 || !(step = ++step % size)) {
+        let tmp: Value = null;
         switch (current) {
 
           // If no current op-code, move on.
           case null: break;
 
-          // OPEN: `000`
-          case 0: break;
+          // OPEN
+          case OP_CODE.OPEN:
+            stack.push([op, val, invert]);
+            val = invert = op = null;
+            break;
 
-          // VAL: `001`
-          case 1:
-            let tmp = invert ? !exprs[next] : !!exprs[next];
+          // VAL: `010`
+          // CLOSE: `000`
+          case OP_CODE.CLOSE:
+            if (!stack.length) break main; // If we've hit a close with no stack, we're done.
+            tmp = val;
+            [ op, val, invert] = stack.pop()!;
+            // Intentionally no break. Falls through to VAL evaluation.
+
+          case OP_CODE.VAL:
+            if (current !== OP_CODE.CLOSE) tmp = !!exprs[next];
+
+            tmp = invert ? !tmp : tmp;
+
             switch (op) {
-              case 3: val = val || tmp; break;
-              case 4: val = val && tmp; break;
-              case 5: val = val === tmp; break;
+              case OP_CODE.OR:    val = val || tmp; break;
+              case OP_CODE.AND:   val = val && tmp; break;
+              case OP_CODE.EQUAL: val = val === tmp; break;
               default: val = tmp;
             }
-            op = null;
-            invert = false;
+
+            invert = op = null;
             break;
 
           // NOT: `010`
-          case 2: invert = true; break;
+          case OP_CODE.NOT: invert = true; break;
 
           // OR: `011`
-          case 3: op = 3; break;
-
           // AND: `100`
-          case 4: op = 4; break;
-
           // EQUAL: `101`
-          case 5: op = 5; break;
-
-          // CLOSE: `110`
-          case 6: break;
+          case OP_CODE.OR:
+          case OP_CODE.AND:
+          case OP_CODE.EQUAL:
+            op = current;
+            break;
 
           // CONCAT: `111`
-          case 7:
+          case OP_CODE.CONCAT:
             out += val ? (out ? " " : "") + classes[klass] : "";
             klass++;
+            op = invert = val = null;
             break;
 
           // If op-code is unrecognized, throw.
@@ -85,12 +107,12 @@ export function runtime(shape: string[], classes: string[], exprs: whatever[]): 
         }
 
         // Begin construction of next opcode. Skip `val` indices.
-        current = (current === 1) ? null : next;
+        current = (current === OP_CODE.VAL) ? null : next;
         next = 0;
       }
     }
-    out += val ? (out ? " " : "") + classes[klass] : "";
   }
 
+  out += val ? (out ? " " : "") + classes[klass] : "";
   return out;
 }

--- a/packages/@css-blocks/runtime/src/runtime.ts
+++ b/packages/@css-blocks/runtime/src/runtime.ts
@@ -1,0 +1,96 @@
+export type whatever = string | number | boolean | symbol | object | null | undefined | void;
+
+export function runtime(shape: string[], classes: string[], exprs: whatever[]): string {
+
+  // We dynamically determine the variable window size based on the number of
+  // expressions it is possible to reference. It is the compiler's responsibility
+  // to guarantee the expression shape matches at build time.
+  const VAR_SIZE = ~~Math.log2(exprs.length - 1) + 1;
+
+  let out     = "";    // Output class list.
+  let klass   = 0;     // Current class we are determining presence for.
+  let val     = null;  // Working boolean expression value.
+  let step    = 0;     // Character count used for opcode discovery.
+  let current = null;  // Current discovered opcode to evaluate.
+  let next    = 0;     // This is a single lookahead parser – next opcode will be stored here.
+  let op      = null;  // Operation to evaluate on next val discovered.
+  let invert  = false; // Should we invert the next discovered value.
+  // let stack    = []; // Stack for nested boolean expressions
+
+  // For each 32 bit integer passed to us as a base 36 string
+  for ( let segment of shape ) {
+
+    // Convert binary string segment to a base 10 integer
+    let integer = parseInt(segment, 36);
+
+    // Process each bit in this 32 bit integer.
+    // Note: `while` loop is faster than a `for` loop here.
+    let iters = 32;
+    while (iters--) {
+
+      // Construct our lookahead opcode and "pop" a bit off the end
+      // of our integer's binary representation.
+      let size = (current === 1 ? VAR_SIZE : 3);
+      next += integer % 2 * (2 * (size - 1 - step) || 1); // tslint:disable-line
+      integer = integer >>> 1;                            // tslint:disable-line
+
+      // When we have discovered the next opcode, process.
+      if (!(step = ++step % size)) {
+
+        // Each opcode type requires implementation
+        switch (current) {
+
+          // If no current op-code, move on.
+          case null: break;
+
+          // OPEN: `000`
+          case 0: break;
+
+          // VAL: `001`
+          case 1:
+            let tmp = invert ? !exprs[next] : !!exprs[next];
+            switch (op) {
+              case 3: val = val || tmp; break;
+              case 4: val = val && tmp; break;
+              case 5: val = val === tmp; break;
+              default: val = tmp;
+            }
+            op = null;
+            invert = false;
+            break;
+
+          // NOT: `010`
+          case 2: invert = true; break;
+
+          // OR: `011`
+          case 3: op = 3; break;
+
+          // AND: `100`
+          case 4: op = 4; break;
+
+          // EQUAL: `101`
+          case 5: op = 5; break;
+
+          // CLOSE: `110`
+          case 6: break;
+
+          // CONCAT: `111`
+          case 7:
+            out += val ? (out ? " " : "") + classes[klass] : "";
+            klass++;
+            break;
+
+          // If op-code is unrecognized, throw.
+          default: throw new Error("Unknown CSS Blocks op-code.");
+        }
+
+        // Begin construction of next opcode. Skip `val` indices.
+        current = (current === 1) ? null : next;
+        next = 0;
+      }
+    }
+    out += val ? (out ? " " : "") + classes[klass] : "";
+  }
+
+  return out;
+}

--- a/packages/@css-blocks/runtime/test/expression-test.ts
+++ b/packages/@css-blocks/runtime/test/expression-test.ts
@@ -1,74 +1,73 @@
 import { assert } from "chai";
 import { suite, test } from "mocha-typescript";
 
-import { Expression, OP_CODE } from "../src/constructor";
-import { runtime } from "../src/runtime";
+import { ExpressionContainer, OP_CODE } from "../src/ExpressionContainer";
 
 @suite("Expression")
 export class ExpressionTests {
 
   @test "simple equality expression"() {
-    let expr = new Expression();
+    let expr = new ExpressionContainer();
     // arg0 === arg1
     expr.apply("fubar").when(true).equals.val(false);
     assert.deepEqual(expr.getClasses(), ["fubar"]);
     assert.deepEqual(expr.getExprs(), [true, false]);
     assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.VAL, "1"]);
-    assert.deepEqual([parseInt(`1${expr.getOps().join("").split("").reverse().join("")}`, 2).toString(36)], expr.getShape());
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false]), "");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true]), "fubar");
+    assert.deepEqual([parseInt(`1${expr.getOps().join("").split("").reverse().join("")}`, 2).toString(36)], expr.getBinaryEncoding());
+    assert.equal(expr.exec(true, false), "");
+    assert.equal(expr.exec(true, true), "fubar");
   }
 
   @test "simple not expression"() {
-    let expr = new Expression();
+    let expr = new ExpressionContainer();
     // arg0 === !arg1
     expr.apply("fubar").when(true).equals.not.val(false);
     assert.deepEqual(expr.getClasses(), ["fubar"]);
     assert.deepEqual(expr.getExprs(), [true, false]);
     assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.NOT, OP_CODE.VAL, "1"]);
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false]), "fubar");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true]), "");
+    assert.equal(expr.exec(true, false), "fubar");
+    assert.equal(expr.exec(true, true), "");
   }
 
   @test "multiple classes"() {
     // arg0 === !arg1 => fubar
     // arg0 === arg2 => bizbaz
-    let expr = new Expression();
+    let expr = new ExpressionContainer();
     expr.apply("fubar").when("arg0").equals.not.val("arg1");
     expr.apply("bizbaz").when("arg0").equals.val("arg2");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "fubar", "1 0 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz", "1 0 1");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, true]), "", "0 0 1");
+    assert.equal(expr.exec(true, false, false), "fubar", "1 0 0");
+    assert.equal(expr.exec(true, false, true), "fubar bizbaz", "1 0 1");
+    assert.equal(expr.exec(false, false, true), "", "0 0 1");
   }
 
   @test "expressions with parens"() {
     // arg0 === (arg1 || arg2) => fubar
     // (arg0 === arg1) || arg2 => bizbaz
-    let expr = new Expression();
+    let expr = new ExpressionContainer();
     expr = expr.apply("fubar").when("arg0").equals.open.val("arg1").or.val("arg2").close;
     expr.apply("bizbaz").open.when("arg0").equals.val("arg1").close.or.val("arg2");
 
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, false]), "fubar bizbaz", "0 0 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "", "1 0 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, false]), "", "0 1 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, true]), "bizbaz", "0 0 1");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true, false]), "fubar bizbaz", "1 1 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz", "1 0 1");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz", "1 1 1");
+    assert.equal(expr.exec(false, false, false), "fubar bizbaz", "0 0 0");
+    assert.equal(expr.exec(true, false, false), "", "1 0 0");
+    assert.equal(expr.exec(false, true, false), "", "0 1 0");
+    assert.equal(expr.exec(false, true, true), "bizbaz", "0 0 1");
+    assert.equal(expr.exec(true, true, false), "fubar bizbaz", "1 1 0");
+    assert.equal(expr.exec(true, false, true), "fubar bizbaz", "1 0 1");
+    assert.equal(expr.exec(true, false, true), "fubar bizbaz", "1 1 1");
   }
 
   @test "deep stack expressions"() {
     // arg0 && (arg1 || !(arg0 && arg2)) => fubar
-    let expr = new Expression();
+    let expr = new ExpressionContainer();
     expr = expr.apply("fubar").when("arg0").and.open.val("arg1").or.not.open.val("arg0").and.val("arg2").close.close;
 
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, false]), "", "0 0 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "fubar", "1 0 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, false]), "", "0 1 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, true]), "", "0 0 1");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true, false]), "fubar", "1 1 0");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "", "1 0 1");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true, true]), "fubar", "1 1 1");
+    assert.equal(expr.exec(false, false, false), "", "0 0 0");
+    assert.equal(expr.exec(true, false, false), "fubar", "1 0 0");
+    assert.equal(expr.exec(false, true, false), "", "0 1 0");
+    assert.equal(expr.exec(false, true, true), "", "0 0 1");
+    assert.equal(expr.exec(true, true, false), "fubar", "1 1 0");
+    assert.equal(expr.exec(true, false, true), "", "1 0 1");
+    assert.equal(expr.exec(true, true, true), "fubar", "1 1 1");
 
   }
 }

--- a/packages/@css-blocks/runtime/test/expression-test.ts
+++ b/packages/@css-blocks/runtime/test/expression-test.ts
@@ -1,73 +1,107 @@
 import { assert } from "chai";
 import { suite, test } from "mocha-typescript";
 
-import { ExpressionContainer, OP_CODE } from "../src/ExpressionContainer";
+import {
+  AND,
+  EQ,
+  ExpressionContainer,
+  NOT,
+  OR,
+  expr,
+} from "../src/ExpressionContainer";
 
-@suite("Expression")
-export class ExpressionTests {
+@suite("Expression Build")
+export class ExpressionBuildTests {
+
+  @test "Binary string and encoding generation properly"() {
+    // arg0 === (arg1 || arg2) => fubar
+    let el = new ExpressionContainer();
+    el.class("fubar", expr(0, EQ, expr(1, OR, 2)));
+    assert.equal(el.getBinaryString(), "000101001110000110");
+    assert.deepEqual(el.getBinaryEncoding(), [parseInt(el.getBinaryString().split("").reverse().join(""), 2).toString(36)]);
+  }
 
   @test "simple equality expression"() {
-    let expr = new ExpressionContainer();
-    // arg0 === arg1
-    expr.apply("fubar").when(true).equals.val(false);
-    assert.deepEqual(expr.getClasses(), ["fubar"]);
-    assert.deepEqual(expr.getExprs(), [true, false]);
-    assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.VAL, "1"]);
-    assert.deepEqual([parseInt(`1${expr.getOps().join("").split("").reverse().join("")}`, 2).toString(36)], expr.getBinaryEncoding());
-    assert.equal(expr.exec(true, false), "");
-    assert.equal(expr.exec(true, true), "fubar");
+    // 0 == 1
+    let el = new ExpressionContainer();
+    el.class("zipzap", expr(0, EQ, 1));
+    assert.deepEqual(el.getExprs(), [{
+      left: 0,
+      op: EQ,
+      right: 1,
+      notLeft: false,
+      notRight: false,
+    }]);
+    assert.equal(el.exec(true, false), "");
+    assert.equal(el.exec(true, true), "zipzap");
+    assert.equal(el.exec(false, false), "zipzap");
   }
 
   @test "simple not expression"() {
-    let expr = new ExpressionContainer();
+    let el = new ExpressionContainer();
     // arg0 === !arg1
-    expr.apply("fubar").when(true).equals.not.val(false);
-    assert.deepEqual(expr.getClasses(), ["fubar"]);
-    assert.deepEqual(expr.getExprs(), [true, false]);
-    assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.NOT, OP_CODE.VAL, "1"]);
-    assert.equal(expr.exec(true, false), "fubar");
-    assert.equal(expr.exec(true, true), "");
+    el.class("fubar", expr(0, EQ, NOT(1)));
+    assert.equal(el.exec(true, false), "fubar");
+    assert.equal(el.exec(true, true), "");
+  }
+
+  @test "deep expression with NOTs"() {
+    // !(0 || 1) && !2
+    let el = new ExpressionContainer();
+    el.class("zipzap", expr(NOT(expr(0, OR, 1)), AND, NOT(2)));
+    assert.deepEqual(el.getExprs(), [{
+      left: {
+        left: 0,
+        op: OR,
+        right: 1,
+        notLeft: false,
+        notRight: false,
+      },
+      op: AND,
+      right: 2,
+      notLeft: true,
+      notRight: true,
+    }]);
   }
 
   @test "multiple classes"() {
     // arg0 === !arg1 => fubar
     // arg0 === arg2 => bizbaz
-    let expr = new ExpressionContainer();
-    expr.apply("fubar").when("arg0").equals.not.val("arg1");
-    expr.apply("bizbaz").when("arg0").equals.val("arg2");
-    assert.equal(expr.exec(true, false, false), "fubar", "1 0 0");
-    assert.equal(expr.exec(true, false, true), "fubar bizbaz", "1 0 1");
-    assert.equal(expr.exec(false, false, true), "", "0 0 1");
+    let el = new ExpressionContainer();
+    el.class("fubar", expr(0, EQ, NOT(1)));
+    el.class("bizbaz", expr(0, EQ, 2));
+    assert.equal(el.exec(true, false, false), "fubar", "1 0 0");
+    assert.equal(el.exec(true, false, true), "fubar bizbaz", "1 0 1");
+    assert.equal(el.exec(false, false, true), "", "0 0 1");
   }
 
   @test "expressions with parens"() {
     // arg0 === (arg1 || arg2) => fubar
     // (arg0 === arg1) || arg2 => bizbaz
-    let expr = new ExpressionContainer();
-    expr = expr.apply("fubar").when("arg0").equals.open.val("arg1").or.val("arg2").close;
-    expr.apply("bizbaz").open.when("arg0").equals.val("arg1").close.or.val("arg2");
+    let el = new ExpressionContainer();
+    el.class("fubar", expr(0, EQ, expr(1, OR, 2)));
+    el.class("bizbaz", expr(expr(0, EQ, 1), OR, 2));
 
-    assert.equal(expr.exec(false, false, false), "fubar bizbaz", "0 0 0");
-    assert.equal(expr.exec(true, false, false), "", "1 0 0");
-    assert.equal(expr.exec(false, true, false), "", "0 1 0");
-    assert.equal(expr.exec(false, true, true), "bizbaz", "0 0 1");
-    assert.equal(expr.exec(true, true, false), "fubar bizbaz", "1 1 0");
-    assert.equal(expr.exec(true, false, true), "fubar bizbaz", "1 0 1");
-    assert.equal(expr.exec(true, false, true), "fubar bizbaz", "1 1 1");
+    assert.equal(el.exec(false, false, false), "fubar bizbaz", "0 0 0");
+    assert.equal(el.exec(true, false, false), "", "1 0 0");
+    assert.equal(el.exec(false, true, false), "", "0 1 0");
+    assert.equal(el.exec(false, true, true), "bizbaz", "0 0 1");
+    assert.equal(el.exec(true, true, false), "fubar bizbaz", "1 1 0");
+    assert.equal(el.exec(true, false, true), "fubar bizbaz", "1 0 1");
+    assert.equal(el.exec(true, false, true), "fubar bizbaz", "1 1 1");
   }
 
   @test "deep stack expressions"() {
     // arg0 && (arg1 || !(arg0 && arg2)) => fubar
-    let expr = new ExpressionContainer();
-    expr = expr.apply("fubar").when("arg0").and.open.val("arg1").or.not.open.val("arg0").and.val("arg2").close.close;
+    let el = new ExpressionContainer();
+    el.class("fubar", expr(0, AND, expr(1, OR, NOT(expr(0, AND, 2)))));
 
-    assert.equal(expr.exec(false, false, false), "", "0 0 0");
-    assert.equal(expr.exec(true, false, false), "fubar", "1 0 0");
-    assert.equal(expr.exec(false, true, false), "", "0 1 0");
-    assert.equal(expr.exec(false, true, true), "", "0 0 1");
-    assert.equal(expr.exec(true, true, false), "fubar", "1 1 0");
-    assert.equal(expr.exec(true, false, true), "", "1 0 1");
-    assert.equal(expr.exec(true, true, true), "fubar", "1 1 1");
-
+    assert.equal(el.exec(false, false, false), "", "0 0 0");
+    assert.equal(el.exec(true, false, false), "fubar", "1 0 0");
+    assert.equal(el.exec(false, true, false), "", "0 1 0");
+    assert.equal(el.exec(false, true, true), "", "0 0 1");
+    assert.equal(el.exec(true, true, false), "fubar", "1 1 0");
+    assert.equal(el.exec(true, false, true), "", "1 0 1");
+    assert.equal(el.exec(true, true, true), "fubar", "1 1 1");
   }
 }

--- a/packages/@css-blocks/runtime/test/expression-test.ts
+++ b/packages/@css-blocks/runtime/test/expression-test.ts
@@ -9,6 +9,7 @@ export class ExpressionTests {
 
   @test "simple equality expression"() {
     let expr = new Expression();
+    // arg0 === arg1
     expr.apply("fubar").when(true).equals.val(false);
     assert.deepEqual(expr.getClasses(), ["fubar"]);
     assert.deepEqual(expr.getExprs(), [true, false]);
@@ -20,7 +21,8 @@ export class ExpressionTests {
 
   @test "simple not expression"() {
     let expr = new Expression();
-    expr.apply("fubar").when(true).equals.not(false);
+    // arg0 === !arg1
+    expr.apply("fubar").when(true).equals.not.val(false);
     assert.deepEqual(expr.getClasses(), ["fubar"]);
     assert.deepEqual(expr.getExprs(), [true, false]);
     assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.NOT, OP_CODE.VAL, "1"]);
@@ -29,11 +31,44 @@ export class ExpressionTests {
   }
 
   @test "multiple classes"() {
+    // arg0 === !arg1 => fubar
+    // arg0 === arg2 => bizbaz
     let expr = new Expression();
-    expr.apply("fubar").when("arg0").equals.not("arg1");
+    expr.apply("fubar").when("arg0").equals.not.val("arg1");
     expr.apply("bizbaz").when("arg0").equals.val("arg2");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "fubar");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz");
-    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, true]), "");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "fubar", "1 0 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz", "1 0 1");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, true]), "", "0 0 1");
+  }
+
+  @test "expressions with parens"() {
+    // arg0 === (arg1 || arg2) => fubar
+    // (arg0 === arg1) || arg2 => bizbaz
+    let expr = new Expression();
+    expr = expr.apply("fubar").when("arg0").equals.open.val("arg1").or.val("arg2").close;
+    expr.apply("bizbaz").open.when("arg0").equals.val("arg1").close.or.val("arg2");
+
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, false]), "fubar bizbaz", "0 0 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "", "1 0 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, false]), "", "0 1 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, true]), "bizbaz", "0 0 1");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true, false]), "fubar bizbaz", "1 1 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz", "1 0 1");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz", "1 1 1");
+  }
+
+  @test "deep stack expressions"() {
+    // arg0 && (arg1 || !(arg0 && arg2)) => fubar
+    let expr = new Expression();
+    expr = expr.apply("fubar").when("arg0").and.open.val("arg1").or.not.open.val("arg0").and.val("arg2").close.close;
+
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, false]), "", "0 0 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "fubar", "1 0 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, false]), "", "0 1 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, true, true]), "", "0 0 1");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true, false]), "fubar", "1 1 0");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "", "1 0 1");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true, true]), "fubar", "1 1 1");
+
   }
 }

--- a/packages/@css-blocks/runtime/test/expression-test.ts
+++ b/packages/@css-blocks/runtime/test/expression-test.ts
@@ -1,9 +1,39 @@
 import { assert } from "chai";
 import { suite, test } from "mocha-typescript";
 
+import { Expression, OP_CODE } from "../src/constructor";
+import { runtime } from "../src/runtime";
+
 @suite("Expression")
 export class ExpressionTests {
-  @test "runs"() {
-    assert.equal(1, 1);
+
+  @test "simple equality expression"() {
+    let expr = new Expression();
+    expr.apply("fubar").when(true).equals.val(false);
+    assert.deepEqual(expr.getClasses(), ["fubar"]);
+    assert.deepEqual(expr.getExprs(), [true, false]);
+    assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.VAL, "1"]);
+    assert.deepEqual([parseInt(`1${expr.getOps().join("").split("").reverse().join("")}`, 2).toString(36)], expr.getShape());
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false]), "");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true]), "fubar");
+  }
+
+  @test "simple not expression"() {
+    let expr = new Expression();
+    expr.apply("fubar").when(true).equals.not(false);
+    assert.deepEqual(expr.getClasses(), ["fubar"]);
+    assert.deepEqual(expr.getExprs(), [true, false]);
+    assert.deepEqual(expr.getOps(), [OP_CODE.VAL, "0", OP_CODE.EQUAL, OP_CODE.NOT, OP_CODE.VAL, "1"]);
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false]), "fubar");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, true]), "");
+  }
+
+  @test "multiple classes"() {
+    let expr = new Expression();
+    expr.apply("fubar").when("arg0").equals.not("arg1");
+    expr.apply("bizbaz").when("arg0").equals.val("arg2");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, false]), "fubar");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [true, false, true]), "fubar bizbaz");
+    assert.equal(runtime(expr.getShape(), expr.getClasses(), [false, false, true]), "");
   }
 }


### PR DESCRIPTION
 Working binary runtime package. Currently clocks in at under 681 bytes minified and will greatly reduce the possibility for template bloat on rewrite. See https://github.com/linkedin/css-blocks/issues/47 for implementation details. To complete:

 - [x] Add support for nested binary expressions.
 - [x] Flesh out runtime test suite.
 - [ ] Finalize expression constructor API.
 - [ ] Integrate expression constructor API with analyzer.
 - [ ] Integrate runtime generation with rewriter.

I expect that the base `ElementAnalysis` object delivered in core will proxy some version of the expression constructor to analyzers. The core rewrite transport object will then expose the three generated array parts – expression shapes array, classes array, and expressions array – to the rewriters to apply as the wish.

> Edit: this is ready to land. I'd like to tackle tasks 3, 4 and 5 in a separate PR now that this is fully functional and tested 👍 