### PR TITLE
[cli] Add support for importing from npm modules and using import aliases.

### DIFF
--- a/packages/@css-blocks/cli/README.md
+++ b/packages/@css-blocks/cli/README.md
@@ -1,6 +1,7 @@
 # CSS Blocks Command Line Interface
 
-The css-blocks Rewriter and Analyzer for Glimmer templates.
+A simple interface for working with CSS Blocks.
+Not meant to replace a proper build tool integration.
 
 ## Installation
 
@@ -17,14 +18,16 @@ npx @css-blocks/cli validate blocks/*.block.css
 ## Usage
 
 ```
-css-blocks <cmd> [options] <blocks..>
+css-blocks <cmd> [options] block-dir-or-file...
 
 Commands:
   css-blocks validate <blocks..>  Validate block file syntax.
 
 Options:
-  --version        Show version number                                 [boolean]
-  --preprocessors  A JS file that exports an object that maps extensions to a
-                   preprocessor function for that type.                 [string]
-  --help           Show help                                           [boolean]
+  --version        Show version number
+  --preprocessors  A JS file that exports an object that maps extensions to a preprocessor function for that type.
+  --npm            Allow importing from node_modules
+  --alias          Define an import alias. Requires two arguments: an alias and a directory.
+  --help           Show help
+
 ```

--- a/packages/@css-blocks/cli/package.json
+++ b/packages/@css-blocks/cli/package.json
@@ -24,6 +24,9 @@
     "remap": "remap-istanbul -i build/coverage/coverage.json -o coverage -t html",
     "watch": "watch 'yarn run test' src test --wait=1"
   },
+  "bin": {
+    "css-blocks": "./bin/css-blocks"
+  },
   "keywords": [
     "css-blocks",
     "css",

--- a/packages/@css-blocks/cli/test/fixtures/.gitignore
+++ b/packages/@css-blocks/cli/test/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/@css-blocks/cli/test/fixtures/importing/alias.block.css
+++ b/packages/@css-blocks/cli/test/fixtures/importing/alias.block.css
@@ -1,0 +1,6 @@
+@block red from "basic/simple.block.css";
+
+:scope {
+  font-family: resolve("red");
+  color: blue;
+}

--- a/packages/@css-blocks/cli/test/fixtures/importing/node_modules/block-module/blocks/font.block.css
+++ b/packages/@css-blocks/cli/test/fixtures/importing/node_modules/block-module/blocks/font.block.css
@@ -1,0 +1,7 @@
+:scope {
+  font-family: sans-serif;
+}
+
+:scope[state|weight=bold] {
+  font-weight: bold;
+}

--- a/packages/@css-blocks/cli/test/fixtures/importing/node_modules/block-module/index.block.css
+++ b/packages/@css-blocks/cli/test/fixtures/importing/node_modules/block-module/index.block.css
@@ -1,0 +1,3 @@
+@block font from "blocks/font.block.css";
+
+@export font;

--- a/packages/@css-blocks/cli/test/fixtures/importing/node_modules/block-module/package.json
+++ b/packages/@css-blocks/cli/test/fixtures/importing/node_modules/block-module/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "block-module",
+  "css-blocks": {
+    "main": "index.block.css"
+  }
+}

--- a/packages/@css-blocks/cli/test/fixtures/importing/npm.block.css
+++ b/packages/@css-blocks/cli/test/fixtures/importing/npm.block.css
@@ -1,0 +1,6 @@
+@block font from "block-module";
+
+:scope {
+  font-family: resolve("font");
+  font-family: serif;
+}

--- a/packages/@css-blocks/core/src/BlockParser/BlockFactory.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockFactory.ts
@@ -145,25 +145,25 @@ export class BlockFactory {
         })
 
         // Run through PostCSS.
-        .then(async (preprocessResult): Promise<[ProcessedFile, postcss.Result]> => {
+        .then(async (preprocessResult): Promise<[ProcessedFile, postcss.Root]> => {
           debug(`Generating PostCSS AST for "${filename}"`);
           let sourceMap = sourceMapFromProcessedFile(preprocessResult);
           let content = preprocessResult.content;
           if (sourceMap) {
             content = annotateCssContentWithSourceMap(content, sourceMap);
           }
-          let result = await this.postcssImpl().process(content, { from: filename });
-          return [preprocessResult, result];
+          let root = await this.postcssImpl.parse(content, { from: filename });
+          return [preprocessResult, root];
         })
 
-        .then(([preprocessedResult, result]) => {
+        .then(([preprocessedResult, root]) => {
           debug(`Parsing Block object for "${filename}"`);
           // Skip parsing if we can.
           if (this.blocks[file.identifier]) { return this.blocks[file.identifier]; }
           let source: ParsedSource = {
             identifier: file.identifier,
             defaultName: file.defaultName,
-            parseResult: result,
+            parseResult: root,
             originalSource: file.contents,
             originalSyntax: file.syntax,
             dependencies: preprocessedResult.dependencies || [],

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -3,7 +3,6 @@ import { postcss } from "opticss";
 
 import { Block } from "../BlockTree";
 import { Options, ResolvedConfiguration, resolveConfiguration } from "../configuration";
-import * as errors from "../errors";
 import { FileIdentifier } from "../importing";
 
 import { assertForeignGlobalAttribute } from "./features/assert-foreign-global-attribute";
@@ -27,7 +26,7 @@ export interface ParsedSource {
   defaultName: string;
   originalSource: string;
   originalSyntax: Syntax;
-  parseResult: postcss.Result;
+  parseResult: postcss.Root;
   dependencies: string[];
 }
 
@@ -45,10 +44,7 @@ export class BlockParser {
   }
 
   public parseSource(source: ParsedSource): Promise<Block> {
-    let root = source.parseResult.root;
-
-    // This should never happen but it makes the typechecker happy.
-    if (!root) { throw new errors.CssBlockError("No postcss root found."); }
+    let root = source.parseResult;
 
     return this.parse(root, source.identifier, source.defaultName).then(block => {
       source.dependencies.forEach(block.addDependency);

--- a/packages/@css-blocks/core/src/configuration/resolver.ts
+++ b/packages/@css-blocks/core/src/configuration/resolver.ts
@@ -28,7 +28,7 @@ const SIMPLE_KEYS: Array<ConfigurationSimpleKeys> = [
 const DEFAULTS: ResolvedConfiguration = {
   outputMode: OutputMode.BEM,
   importer: defaultImporter,
-  rootDir: process.cwd(),
+  rootDir: "",
   importerData: {},
   preprocessors: {},
   disablePreprocessChaining: false,
@@ -43,6 +43,7 @@ class Resolver implements ResolvedConfiguration {
 
   constructor(options?: Options, defaults?: Options) {
     this._opts = { ...DEFAULTS };
+    this.setAll({rootDir: process.cwd()});
     this.setAll(defaults);
     this.setAll(options);
   }


### PR DESCRIPTION
This patch provides CLI options to allow imports to come from node_modules and to define import aliases.

The tests for this feature change the working directory which exposed that the current working directory was being cached at the time of import.