### PR TITLE
Better Error Reporting (Phase 1)

### DIFF
--- a/packages/@css-blocks/cli/src/extract-lines-from-source.ts
+++ b/packages/@css-blocks/cli/src/extract-lines-from-source.ts
@@ -10,7 +10,7 @@ export interface ExtractionResult {
 export function extractLinesFromSource(
   range: Required<SourceRange> & { source?: string },
   additionalLinesBefore = 1,
-  additionalLinesAfter = 0,
+  additionalLinesAfter = 1,
 ): ExtractionResult | undefined {
   let contents: string | undefined;
   let { filename, start, end, source } = range;

--- a/packages/@css-blocks/cli/src/extract-lines-from-source.ts
+++ b/packages/@css-blocks/cli/src/extract-lines-from-source.ts
@@ -8,12 +8,17 @@ export interface ExtractionResult {
   };
 }
 export function extractLinesFromSource(
-  range: Required<SourceRange>,
+  range: Required<SourceRange> & { source?: string },
   additionalLinesBefore = 1,
   additionalLinesAfter = 0,
-): ExtractionResult {
-  let { filename, start, end } = range;
-  let contents = fs.readFileSync(filename, "utf-8");
+): ExtractionResult | undefined {
+  let contents: string | undefined;
+  let { filename, start, end, source } = range;
+  try {
+    contents = source || fs.readFileSync(filename, "utf-8");
+  } catch (e) {
+    return;
+  }
   let allLines = contents.split(/\r?\n/);
   if (start.line <= additionalLinesBefore) {
     additionalLinesBefore = start.line - 1;

--- a/packages/@css-blocks/cli/src/extract-lines-from-source.ts
+++ b/packages/@css-blocks/cli/src/extract-lines-from-source.ts
@@ -1,0 +1,34 @@
+import { SourceRange } from "@css-blocks/core";
+import * as fs from "fs";
+export interface ExtractionResult {
+  lines: string[];
+  additionalLines: {
+    before: number;
+    after: number;
+  };
+}
+export function extractLinesFromSource(
+  range: Required<SourceRange>,
+  additionalLinesBefore = 1,
+  additionalLinesAfter = 0,
+): ExtractionResult {
+  let { filename, start, end } = range;
+  let contents = fs.readFileSync(filename, "utf-8");
+  let allLines = contents.split(/\r?\n/);
+  if (start.line <= additionalLinesBefore) {
+    additionalLinesBefore = start.line - 1;
+  }
+  if (end.line + additionalLinesAfter > allLines.length ) {
+    additionalLinesAfter = allLines.length - end.line;
+  }
+  let firstLine = start.line - additionalLinesBefore - 1;
+  let lastLine = end.line + additionalLinesAfter;
+  let lines = allLines.slice(firstLine, lastLine);
+  return {
+    lines,
+    additionalLines: {
+      before: additionalLinesBefore,
+      after: additionalLinesAfter,
+    },
+  };
+}

--- a/packages/@css-blocks/cli/src/index.ts
+++ b/packages/@css-blocks/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { BlockFactory, CssBlockError, Importer, NodeJsImporter, Preprocessors } from "@css-blocks/core";
+import { BlockFactory, CssBlockError, Importer, NodeJsImporter, Preprocessors, hasErrorPosition } from "@css-blocks/core";
 import chalk = require("chalk");
 import fse = require("fs-extra");
 import path = require("path");
@@ -137,8 +137,8 @@ export class CLI {
           let loc = e.location;
           let filename = path.relative(process.cwd(), path.resolve(loc && loc.filename || blockFile));
           let message = `${this.chalk.red("error")}\t${this.chalk.whiteBright(filename)}`;
-          if (loc && loc.filename && loc.line && loc.column) {
-            message += `:${loc.line}:${loc.column}`;
+          if (hasErrorPosition(loc)) {
+            message += `:${loc.start.line}:${loc.start.column}`;
           }
           message += ` ${e.origMessage}`;
           this.println(message);

--- a/packages/@css-blocks/cli/src/index.ts
+++ b/packages/@css-blocks/cli/src/index.ts
@@ -5,7 +5,8 @@ import {
   Importer,
   NodeJsImporter,
   Preprocessors,
-  hasErrorPosition,
+  charInFile,
+  errorHasRange,
   hasMappedPosition,
 } from "@css-blocks/core";
 import chalk = require("chalk");
@@ -148,7 +149,7 @@ export class CLI {
         if (e instanceof CssBlockError) {
           let loc = e.location;
           let message = `${this.chalk.red("error")}\t${this.chalk.whiteBright(blockFileRelative)}`;
-          if (!hasErrorPosition(loc)) {
+          if (!errorHasRange(loc)) {
             this.println(message, e.origMessage);
             continue;
           } else {
@@ -168,21 +169,20 @@ export class CLI {
 
   displayError(blockFileRelative: string, e: CssBlockError) {
     let loc = e.location;
-    if (!hasErrorPosition(loc)) {
-      return;
-    }
+    if (!loc) return;
+    if (!errorHasRange(loc)) return;
     let filename = path.relative(process.cwd(), path.resolve(loc && loc.filename || blockFileRelative));
     this.println("\t" + this.chalk.bold.redBright(e.origMessage));
     if (hasMappedPosition(loc)) {
       this.println(
         this.chalk.bold.white("\tAt compiled output of"),
-        this.chalk.bold.whiteBright(`${loc.generated.filename}:${loc.generated.start.line}:${loc.generated.start.column}`),
+        this.chalk.bold.whiteBright(charInFile(loc.generated)),
       );
       this.displaySnippet(extractLinesFromSource(loc.generated), loc.generated);
     }
     this.println(
       this.chalk.bold.white(hasMappedPosition(loc) ? "\tSource Mapped to" : "\tAt"),
-      this.chalk.bold.whiteBright(`${filename}:${loc.start.line}:${loc.start.column}`),
+      this.chalk.bold.whiteBright(charInFile(filename, loc.start)),
     );
     this.displaySnippet(extractLinesFromSource(loc), loc);
   }

--- a/packages/@css-blocks/cli/src/index.ts
+++ b/packages/@css-blocks/cli/src/index.ts
@@ -138,7 +138,7 @@ export class CLI {
       try {
         if (importer) {
           let ident = importer.identifier(null, blockFile, factory.configuration);
-          blockFile = importer.filesystemPath(ident, factory.configuration) || path.join(blockFile);
+          blockFile = importer.filesystemPath(ident, factory.configuration) || blockFile;
         }
         await factory.getBlockFromPath(path.resolve(blockFile));
         // if the above line doesn't throw then there wasn't a syntax error.

--- a/packages/@css-blocks/cli/src/index.ts
+++ b/packages/@css-blocks/cli/src/index.ts
@@ -178,13 +178,13 @@ export class CLI {
         this.chalk.bold.white("\tAt compiled output of"),
         this.chalk.bold.whiteBright(`${loc.generated.filename}:${loc.generated.start.line}:${loc.generated.start.column}`),
       );
-      this.displaySnippet(extractLinesFromSource(loc.generated, 1, 1), loc.generated);
+      this.displaySnippet(extractLinesFromSource(loc.generated), loc.generated);
     }
     this.println(
       this.chalk.bold.white(hasMappedPosition(loc) ? "\tSource Mapped to" : "\tAt"),
       this.chalk.bold.whiteBright(`${filename}:${loc.start.line}:${loc.start.column}`),
     );
-    this.displaySnippet(extractLinesFromSource(loc, 1, 1), loc);
+    this.displaySnippet(extractLinesFromSource(loc), loc);
   }
 
   displaySnippet(context: ExtractionResult | undefined, loc: ErrorWithPosition) {

--- a/packages/@css-blocks/cli/test/TestCLI.ts
+++ b/packages/@css-blocks/cli/test/TestCLI.ts
@@ -8,8 +8,8 @@ export class TestCLI extends CLI {
     this.output = "";
     this.chalk.enabled = false;
   }
-  println(text: string) {
-    this.output += text + "\n";
+  println(...texts: string[]) {
+    this.output += texts.join(" ") + "\n";
   }
   argumentParser() {
     let parser = super.argumentParser();

--- a/packages/@css-blocks/cli/test/cli-test.ts
+++ b/packages/@css-blocks/cli/test/cli-test.ts
@@ -29,13 +29,27 @@ describe("validate", () => {
   it("can check syntax for a bad block file", async () => {
     let cli = new CLI();
     await cli.run(["validate", fixture("basic/error.block.css")]);
-    assert.equal(cli.output, `error\t${relFixture("basic/error.block.css")}:1:5 Two distinct classes cannot be selected on the same element: .foo.bar\n`);
+    assert.equal(cli.output,
+                 `error\t${relFixture("basic/error.block.css")}
+\tAt ${relFixture("basic/error.block.css")}:1:5 Two distinct classes cannot be selected on the same element: .foo.bar
+\t1: .foo.bar {
+\t2:   color: red;
+\t3: }
+Found 1 error in 1 file.
+`);
     assert.equal(cli.exitCode, 1);
   });
   it("correctly displays errors in referenced blocks.", async () => {
     let cli = new CLI();
     await cli.run(["validate", fixture("basic/transitive-error.block.css")]);
-    assert.equal(cli.output, `error\t${relFixture("basic/error.block.css")}:1:5 Two distinct classes cannot be selected on the same element: .foo.bar\n`);
+    assert.equal(cli.output,
+                 `error\t${relFixture("basic/transitive-error.block.css")}
+\tAt ${relFixture("basic/error.block.css")}:1:5 Two distinct classes cannot be selected on the same element: .foo.bar
+\t1: .foo.bar {
+\t2:   color: red;
+\t3: }
+Found 1 error in 1 file.
+`);
     assert.equal(cli.exitCode, 1);
   });
   it("can import from node_modules", async () => {
@@ -64,7 +78,7 @@ describe("validate with preprocessors", () => {
   it("can check syntax for a bad block file", async () => {
     let cli = new CLI();
     await cli.run(["validate", "--preprocessors", distFile("test/preprocessors"), fixture("scss/error.block.scss")]);
-    assert.equal(cli.output, `error\t${relFixture("scss/error.block.scss")}:5:5 Two distinct classes cannot be selected on the same element: .foo.bar\n`);
+    assert.equal(cli.output.split(/\n/)[1].trim(), `At ${relFixture("scss/error.block.scss")}:5:5 Two distinct classes cannot be selected on the same element: .foo.bar`);
     assert.equal(cli.exitCode, 1);
   });
 });

--- a/packages/@css-blocks/cli/test/cli-test.ts
+++ b/packages/@css-blocks/cli/test/cli-test.ts
@@ -92,4 +92,21 @@ Found 1 error in 1 file.
 `);
     assert.equal(cli.exitCode, 1);
   });
+  it("can check syntax for a style lookup failure", async () => {
+    let cli = new CLI();
+    await cli.run(["validate", "--preprocessors", distFile("test/preprocessors"), fixture("scss/missing-style.block.scss")]);
+    assert.equal(cli.output, `error\ttest/fixtures/scss/missing-style.block.scss
+\tNo style "simple[state|light]" found.
+\tAt compiled output of test/fixtures/scss/missing-style.block.scss:3:3
+\t2: .composer {
+\t3:   composes: "simple[state|light]";
+\t4:   color: blue;
+\tSource Mapped to test/fixtures/scss/missing-style.block.scss:4:3
+\t3: .composer {
+\t4:   composes: "simple[state|light]";
+\t5:   color: blue;
+Found 1 error in 1 file.
+`);
+    assert.equal(cli.exitCode, 1);
+  });
 });

--- a/packages/@css-blocks/cli/test/cli-test.ts
+++ b/packages/@css-blocks/cli/test/cli-test.ts
@@ -31,10 +31,10 @@ describe("validate", () => {
     await cli.run(["validate", fixture("basic/error.block.css")]);
     assert.equal(cli.output,
                  `error\t${relFixture("basic/error.block.css")}
-\tAt ${relFixture("basic/error.block.css")}:1:5 Two distinct classes cannot be selected on the same element: .foo.bar
+\tTwo distinct classes cannot be selected on the same element: .foo.bar
+\tAt ${relFixture("basic/error.block.css")}:1:5
 \t1: .foo.bar {
 \t2:   color: red;
-\t3: }
 Found 1 error in 1 file.
 `);
     assert.equal(cli.exitCode, 1);
@@ -44,10 +44,10 @@ Found 1 error in 1 file.
     await cli.run(["validate", fixture("basic/transitive-error.block.css")]);
     assert.equal(cli.output,
                  `error\t${relFixture("basic/transitive-error.block.css")}
-\tAt ${relFixture("basic/error.block.css")}:1:5 Two distinct classes cannot be selected on the same element: .foo.bar
+\tTwo distinct classes cannot be selected on the same element: .foo.bar
+\tAt ${relFixture("basic/error.block.css")}:1:5
 \t1: .foo.bar {
 \t2:   color: red;
-\t3: }
 Found 1 error in 1 file.
 `);
     assert.equal(cli.exitCode, 1);
@@ -78,7 +78,18 @@ describe("validate with preprocessors", () => {
   it("can check syntax for a bad block file", async () => {
     let cli = new CLI();
     await cli.run(["validate", "--preprocessors", distFile("test/preprocessors"), fixture("scss/error.block.scss")]);
-    assert.equal(cli.output.split(/\n/)[1].trim(), `At ${relFixture("scss/error.block.scss")}:5:5 Two distinct classes cannot be selected on the same element: .foo.bar`);
+    assert.equal(cli.output, `error	test/fixtures/scss/error.block.scss
+\tTwo distinct classes cannot be selected on the same element: .foo.bar
+\tAt compiled output of test/fixtures/scss/error.block.scss:5:5
+\t4:
+\t5: .foo.bar {
+\t6:   color: blue;
+\tSource Mapped to test/fixtures/scss/error.block.scss:3:5
+\t2:
+\t3: .foo {
+\t4:   color: red;
+Found 1 error in 1 file.
+`);
     assert.equal(cli.exitCode, 1);
   });
 });

--- a/packages/@css-blocks/cli/test/fixtures/basic/attribute-error.block.css
+++ b/packages/@css-blocks/cli/test/fixtures/basic/attribute-error.block.css
@@ -1,0 +1,3 @@
+.foo[disabled=disabled] {
+  color: red;
+}

--- a/packages/@css-blocks/cli/test/fixtures/scss/another-error.block.scss
+++ b/packages/@css-blocks/cli/test/fixtures/scss/another-error.block.scss
@@ -1,0 +1,7 @@
+@import "mixins";
+
+.a {
+  @include plus-b() {
+    color: purple;
+  }
+}

--- a/packages/@css-blocks/cli/test/fixtures/scss/error.block.scss
+++ b/packages/@css-blocks/cli/test/fixtures/scss/error.block.scss
@@ -1,6 +1,8 @@
+@import "mixins";
+
 .foo {
   color: red;
-  &.bar {
+  @include add-bar() {
     color: blue;
   }
 }

--- a/packages/@css-blocks/cli/test/fixtures/scss/missing-style.block.scss
+++ b/packages/@css-blocks/cli/test/fixtures/scss/missing-style.block.scss
@@ -1,0 +1,6 @@
+@block simple from "./simple.block.scss";
+
+.composer {
+  composes: "simple[state|light]";
+  color: blue;
+}

--- a/packages/@css-blocks/cli/test/fixtures/scss/mixins.scss
+++ b/packages/@css-blocks/cli/test/fixtures/scss/mixins.scss
@@ -1,0 +1,24 @@
+@mixin add-bar() {
+  &.bar {
+    @content;
+  }
+}
+
+@mixin plus-b() {
+  & + .bbb {
+    @content;
+  }
+}
+
+@mixin in-state($state-name, $state-value: null) {
+  @if $state-value {
+    &[state|#{$state-name}=#{$state-value}] {
+      @content;
+    }
+  }
+  @else {
+    &[state|#{$state-name}] {
+      @content;
+    }
+  }
+}

--- a/packages/@css-blocks/cli/test/fixtures/scss/tagname-error.block.scss
+++ b/packages/@css-blocks/cli/test/fixtures/scss/tagname-error.block.scss
@@ -1,0 +1,7 @@
+@import "mixins";
+
+div         {
+  @include in-state(selected) {
+    outline: 1px dotted black;
+  }
+}

--- a/packages/@css-blocks/cli/test/preprocessors.ts
+++ b/packages/@css-blocks/cli/test/preprocessors.ts
@@ -9,6 +9,7 @@ const scss: Preprocessors["scss"] = async (fullPath, content, _configuration, _s
         outFile: fullPath.replace("scss", "css"),
         data: content,
         sourceMap: true,
+        sourceMapContents: true,
         outputStyle: "expanded",
         indentedSyntax: false,
       },

--- a/packages/@css-blocks/cli/test/preprocessors.ts
+++ b/packages/@css-blocks/cli/test/preprocessors.ts
@@ -9,7 +9,6 @@ const scss: Preprocessors["scss"] = async (fullPath, content, _configuration, _s
         outFile: fullPath.replace("scss", "css"),
         data: content,
         sourceMap: true,
-        sourceMapContents: true,
         outputStyle: "expanded",
         indentedSyntax: false,
       },

--- a/packages/@css-blocks/core/src/Analyzer/validations/index.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/index.ts
@@ -99,8 +99,15 @@ export class TemplateValidator {
   validate(templateAnalysis: Analysis<keyof TemplateTypes>, element: ElementAnalysis<any, any, any>) {
 
     function err (message: string, locInfo?: errors.ErrorLocation | undefined | null, details?: string) {
+      let location = locInfo || {
+          filename: templateAnalysis.template.identifier,
+          start: element.sourceLocation.start,
+          end: element.sourceLocation.end
+               || { line: element.sourceLocation.start.line,
+                    column: (element.sourceLocation.start.column || 0) + 1},
+        };
       throw new errors.TemplateAnalysisError(
-        message, locInfo || element.sourceLocation.start, details);
+        message, location, details);
     }
 
     this.validators.forEach((func) => {

--- a/packages/@css-blocks/core/src/Analyzer/validations/property-conflict-validator.ts
+++ b/packages/@css-blocks/core/src/Analyzer/validations/property-conflict-validator.ts
@@ -3,6 +3,7 @@ import * as propParser from "css-property-parser";
 import { postcss } from "opticss";
 
 import { AttrValue, BlockClass, Ruleset, Style, isBlockClass } from "../../BlockTree";
+import { charInFile } from "../../errors";
 import {
   ElementAnalysis,
   isAttrGroup,
@@ -131,9 +132,7 @@ function formatRulesetConflicts(prop: string, rules: Ruleset<Style>[]) {
     let decl = rule.declarations.get(prop);
     let nodes: postcss.Rule[] | postcss.Declaration[] =  decl ? decl.map((d) => d.node) : [rule.node];
     for (let node of nodes) {
-      let line = node.source && node.source.start && `:${node.source.start.line}` || "";
-      let column = node.source && node.source.start && `:${node.source.start.column}` || "";
-      out.add(`    ${rule.style.asSource(true)} (${rule.file}${line}${column})`);
+      out.add(`    ${rule.style.asSource(true)} (${charInFile(rule.file, node.source && node.source.start)})`);
     }
   }
   return [...out].join("\n");

--- a/packages/@css-blocks/core/src/BlockCompiler/ConflictResolver.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/ConflictResolver.ts
@@ -435,6 +435,6 @@ export class ConflictResolver {
   }
   sourceRange(block: Block, node: postcss.Node): SourceRange | SourceFile | undefined {
     let blockPath = this.config.importer.debugIdentifier(block.identifier, this.config);
-    return sourceRange(blockPath, node);
+    return sourceRange(this.config, block.stylesheet, blockPath, node);
   }
 }

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -73,7 +73,7 @@ export class BlockCompiler {
    */
   public processDebugStatements(sourceFile: string, root: postcss.Root, block: Block) {
     root.walkAtRules(BLOCK_DEBUG, (atRule) => {
-      let {block: ref, channel} = parseBlockDebug(atRule, sourceFile, block);
+      let {block: ref, channel} = parseBlockDebug(this.config, root, atRule, sourceFile, block);
       if (channel === "comment") {
         let text = `${ref.debug(this.config).join("\n * ")}\n`;
         atRule.replaceWith(this.postcss.comment({ text }));

--- a/packages/@css-blocks/core/src/BlockParser/BlockFactory.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockFactory.ts
@@ -175,7 +175,7 @@ export class BlockFactory {
     let sourceMap = sourceMapFromProcessedFile(preprocessResult);
     let content = preprocessResult.content;
     if (sourceMap) {
-      content = annotateCssContentWithSourceMap(content, sourceMap);
+      content = annotateCssContentWithSourceMap(this.configuration, filename, content, sourceMap);
     }
     let root = await this.postcssImpl.parse(content, { from: filename });
 

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -85,10 +85,10 @@ export class BlockParser {
     await globalAttributes(root, block, sourceFile);
     // Parse all block styles and build block tree.
     debug(` - Construct Block`);
-    await constructBlock(root, block, debugIdent);
+    await constructBlock(root, block, this.factory.configuration, debugIdent);
     // Verify that external blocks referenced have been imported, have defined the attribute being selected, and have marked it as a global state.
     debug(` - Assert Foreign Globals`);
-    await assertForeignGlobalAttribute(root, block, debugIdent);
+    await assertForeignGlobalAttribute(this.factory.configuration, root, block, debugIdent);
     // Construct block extensions and validate.
     debug(` - Extend Block`);
     await extendBlock(root, block, debugIdent);

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -63,17 +63,18 @@ export class BlockParser {
     let importer = this.config.importer;
     let debugIdent = importer.debugIdentifier(identifier, this.config);
     let sourceFile = importer.filesystemPath(identifier, this.config) || debugIdent;
+    let configuration = this.factory.configuration;
     debug(`Begin parse: "${debugIdent}"`);
 
     // Discover the block's preferred name.
-    name = await discoverName(this.factory.configuration, root, name, sourceFile);
+    name = await discoverName(configuration, root, name, sourceFile);
 
     // Create our new Block object and save reference to the raw AST.
     let block = new Block(name, identifier, root);
 
     // Throw if we encounter any `!important` decls.
     debug(` - Disallow Import`);
-    await disallowImportant(this.factory.configuration, root, sourceFile);
+    await disallowImportant(configuration, root, sourceFile);
     // Discover and parse all block references included by this block.
     debug(` - Import Blocks`);
     await importBlocks(block, this.factory, sourceFile);
@@ -82,21 +83,21 @@ export class BlockParser {
     await exportBlocks(block, this.factory, sourceFile);
     // Handle any global attributes defined by this block.
     debug(` - Global Attributes`);
-    await globalAttributes(this.factory.configuration, root, block, sourceFile);
+    await globalAttributes(configuration, root, block, sourceFile);
     // Parse all block styles and build block tree.
     debug(` - Construct Block`);
-    await constructBlock(this.factory.configuration, root, block, debugIdent);
+    await constructBlock(configuration, root, block, debugIdent);
     // Verify that external blocks referenced have been imported, have defined the attribute being selected, and have marked it as a global state.
     debug(` - Assert Foreign Globals`);
-    await assertForeignGlobalAttribute(this.factory.configuration, root, block, debugIdent);
+    await assertForeignGlobalAttribute(configuration, root, block, debugIdent);
     // Construct block extensions and validate.
     debug(` - Extend Block`);
-    await extendBlock(this.factory.configuration, root, block, debugIdent);
+    await extendBlock(configuration, root, block, debugIdent);
     // Validate that all required Styles are implemented.
     debug(` - Implement Block`);
-    await implementBlock(this.factory.configuration, root, block, debugIdent);
+    await implementBlock(configuration, root, block, debugIdent);
     // Register all block compositions.
-    await composeBlock(this.factory.configuration, root, block, debugIdent);
+    await composeBlock(configuration, root, block, debugIdent);
     // Log any debug statements discovered.
     debug(` - Process Debugs`);
     await processDebugStatements(root, block, debugIdent, this.config);

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -66,14 +66,14 @@ export class BlockParser {
     debug(`Begin parse: "${debugIdent}"`);
 
     // Discover the block's preferred name.
-    name = await discoverName(root, name, sourceFile);
+    name = await discoverName(this.factory.configuration, root, name, sourceFile);
 
     // Create our new Block object and save reference to the raw AST.
     let block = new Block(name, identifier, root);
 
     // Throw if we encounter any `!important` decls.
     debug(` - Disallow Import`);
-    await disallowImportant(root, sourceFile);
+    await disallowImportant(this.factory.configuration, root, sourceFile);
     // Discover and parse all block references included by this block.
     debug(` - Import Blocks`);
     await importBlocks(block, this.factory, sourceFile);
@@ -82,21 +82,21 @@ export class BlockParser {
     await exportBlocks(block, this.factory, sourceFile);
     // Handle any global attributes defined by this block.
     debug(` - Global Attributes`);
-    await globalAttributes(root, block, sourceFile);
+    await globalAttributes(this.factory.configuration, root, block, sourceFile);
     // Parse all block styles and build block tree.
     debug(` - Construct Block`);
-    await constructBlock(root, block, this.factory.configuration, debugIdent);
+    await constructBlock(this.factory.configuration, root, block, debugIdent);
     // Verify that external blocks referenced have been imported, have defined the attribute being selected, and have marked it as a global state.
     debug(` - Assert Foreign Globals`);
     await assertForeignGlobalAttribute(this.factory.configuration, root, block, debugIdent);
     // Construct block extensions and validate.
     debug(` - Extend Block`);
-    await extendBlock(root, block, debugIdent);
+    await extendBlock(this.factory.configuration, root, block, debugIdent);
     // Validate that all required Styles are implemented.
     debug(` - Implement Block`);
-    await implementBlock(root, block, debugIdent);
+    await implementBlock(this.factory.configuration, root, block, debugIdent);
     // Register all block compositions.
-    await composeBlock(root, block, debugIdent);
+    await composeBlock(this.factory.configuration, root, block, debugIdent);
     // Log any debug statements discovered.
     debug(` - Process Debugs`);
     await processDebugStatements(root, block, debugIdent, this.config);

--- a/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
@@ -3,7 +3,7 @@ import { postcss, postcssSelectorParser as selectorParser } from "opticss";
 import { Block } from "../../BlockTree";
 import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
-import { selectorSourceRange as loc } from "../../SourceLocation";
+import { selectorSourceRange as range } from "../../SourceLocation";
 import { isAttributeNode, toAttrToken } from "../block-intermediates";
 
 /**
@@ -36,7 +36,7 @@ export async function assertForeignGlobalAttribute(configuration: Configuration,
           if (!isAttributeNode(node)) {
             throw new errors.InvalidBlockSyntax(
               `Only global states from other blocks can be used in selectors: ${rule.selector}`,
-              loc(configuration, block.stylesheet, file, rule, node));
+              range(configuration, block.stylesheet, file, rule, node));
           }
 
           // If referenced block does not exist, throw.
@@ -44,7 +44,7 @@ export async function assertForeignGlobalAttribute(configuration: Configuration,
           if (!otherBlock) {
             throw new errors.InvalidBlockSyntax(
               `No Block named "${blockName.value}" found in scope: ${rule.selector}`,
-              loc(configuration, block.stylesheet, file, rule, node));
+              range(configuration, block.stylesheet, file, rule, node));
           }
 
           // If state referenced does not exist on external block, throw
@@ -52,14 +52,14 @@ export async function assertForeignGlobalAttribute(configuration: Configuration,
           if (!otherAttr) {
             throw new errors.InvalidBlockSyntax(
               `No state ${node.toString()} found in : ${rule.selector}`,
-              loc(configuration, block.stylesheet, file, rule, node));
+              range(configuration, block.stylesheet, file, rule, node));
           }
 
           // If external state is not set as global, throw.
           if (!otherAttr.isGlobal) {
             throw new errors.InvalidBlockSyntax(
               `${node.toString()} is not global: ${rule.selector}`,
-              loc(configuration, block.stylesheet, file, rule, node));
+              range(configuration, block.stylesheet, file, rule, node));
           }
 
         }

--- a/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
@@ -1,6 +1,7 @@
 import { postcss, postcssSelectorParser as selectorParser } from "opticss";
 
 import { Block } from "../../BlockTree";
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { selectorSourceRange as loc } from "../../SourceLocation";
 import { isAttributeNode, toAttrToken } from "../block-intermediates";
@@ -12,7 +13,7 @@ import { isAttributeNode, toAttrToken } from "../block-intermediates";
  * @param rule The rule referencing the external block.
  * @param obj The parsed node making the external reference.
  */
-export async function assertForeignGlobalAttribute(root: postcss.Root, block: Block, file: string) {
+export async function assertForeignGlobalAttribute(configuration: Configuration, root: postcss.Root, block: Block, file: string) {
 
   root.walkRules((rule) => {
 
@@ -35,7 +36,7 @@ export async function assertForeignGlobalAttribute(root: postcss.Root, block: Bl
           if (!isAttributeNode(node)) {
             throw new errors.InvalidBlockSyntax(
               `Only global states from other blocks can be used in selectors: ${rule.selector}`,
-              loc(file, rule, node));
+              loc(configuration, block.stylesheet, file, rule, node));
           }
 
           // If referenced block does not exist, throw.
@@ -43,7 +44,7 @@ export async function assertForeignGlobalAttribute(root: postcss.Root, block: Bl
           if (!otherBlock) {
             throw new errors.InvalidBlockSyntax(
               `No Block named "${blockName.value}" found in scope: ${rule.selector}`,
-              loc(file, rule, node));
+              loc(configuration, block.stylesheet, file, rule, node));
           }
 
           // If state referenced does not exist on external block, throw
@@ -51,14 +52,14 @@ export async function assertForeignGlobalAttribute(root: postcss.Root, block: Bl
           if (!otherAttr) {
             throw new errors.InvalidBlockSyntax(
               `No state ${node.toString()} found in : ${rule.selector}`,
-              loc(file, rule, node));
+              loc(configuration, block.stylesheet, file, rule, node));
           }
 
           // If external state is not set as global, throw.
           if (!otherAttr.isGlobal) {
             throw new errors.InvalidBlockSyntax(
               `${node.toString()} is not global: ${rule.selector}`,
-              loc(file, rule, node));
+              loc(configuration, block.stylesheet, file, rule, node));
           }
 
         }

--- a/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/assert-foreign-global-attribute.ts
@@ -2,7 +2,7 @@ import { postcss, postcssSelectorParser as selectorParser } from "opticss";
 
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { selectorSourceLocation as loc } from "../../SourceLocation";
+import { selectorSourceRange as loc } from "../../SourceLocation";
 import { isAttributeNode, toAttrToken } from "../block-intermediates";
 
 /**

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -4,7 +4,7 @@ import { isRule } from "opticss/dist/src/util/cssIntrospection";
 import { COMPOSES } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { sourceLocation } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 import { getStyleTargets } from "../block-intermediates";
 import { stripQuotes } from "../utils";
 
@@ -17,7 +17,7 @@ import { stripQuotes } from "../utils";
  */
 export async function composeBlock(root: postcss.Root, block: Block, sourceFile: string) {
   root.walkDecls(COMPOSES, (decl) => {
-    if (!isRule(decl.parent)) { throw new errors.InvalidBlockSyntax(`The "composes" property may only be used in a rule set.`, sourceLocation(sourceFile, decl)); }
+    if (!isRule(decl.parent)) { throw new errors.InvalidBlockSyntax(`The "composes" property may only be used in a rule set.`, sourceRange(sourceFile, decl)); }
     let rule = decl.parent;
 
     // TODO: Move to Block Syntax as parseBlockRefList().
@@ -25,16 +25,16 @@ export async function composeBlock(root: postcss.Root, block: Block, sourceFile:
     for (let refName of refNames) {
       let refStyle = block.lookup(refName);
       if (!refStyle) {
-        throw new errors.InvalidBlockSyntax(`No style "${refName}" found.`, sourceLocation(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`No style "${refName}" found.`, sourceRange(sourceFile, decl));
       }
       if (refStyle.block === block) {
-        throw new errors.InvalidBlockSyntax(`Styles from the same Block may not be composed together.`, sourceLocation(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`Styles from the same Block may not be composed together.`, sourceRange(sourceFile, decl));
       }
 
       const parsedSel = block.getParsedSelectors(rule);
       for (let sel of parsedSel) {
         if (sel.selector.next) {
-          throw new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a scope selector.`, sourceLocation(sourceFile, decl));
+          throw new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a scope selector.`, sourceRange(sourceFile, decl));
         }
         let foundStyles = getStyleTargets(block, sel.selector);
         for (let blockClass of foundStyles.blockClasses) {

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -7,6 +7,7 @@ import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
 import { getStyleTargets } from "../block-intermediates";
 import { stripQuotes } from "../utils";
+import { Configuration } from "../../configuration";
 
 /**
  * For each `composes` property found in the passed ruleset, track the foreign
@@ -15,9 +16,9 @@ import { stripQuotes } from "../utils";
  * @param sourceFile  Source file name, used for error output.
  * @param rule Ruleset to crawl
  */
-export async function composeBlock(root: postcss.Root, block: Block, sourceFile: string) {
+export async function composeBlock(configuration: Configuration, root: postcss.Root, block: Block, sourceFile: string) {
   root.walkDecls(COMPOSES, (decl) => {
-    if (!isRule(decl.parent)) { throw new errors.InvalidBlockSyntax(`The "composes" property may only be used in a rule set.`, sourceRange(sourceFile, decl)); }
+    if (!isRule(decl.parent)) { throw new errors.InvalidBlockSyntax(`The "composes" property may only be used in a rule set.`, sourceRange(configuration, root, sourceFile, decl)); }
     let rule = decl.parent;
 
     // TODO: Move to Block Syntax as parseBlockRefList().
@@ -25,16 +26,16 @@ export async function composeBlock(root: postcss.Root, block: Block, sourceFile:
     for (let refName of refNames) {
       let refStyle = block.lookup(refName);
       if (!refStyle) {
-        throw new errors.InvalidBlockSyntax(`No style "${refName}" found.`, sourceRange(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`No style "${refName}" found.`, sourceRange(configuration, root, sourceFile, decl));
       }
       if (refStyle.block === block) {
-        throw new errors.InvalidBlockSyntax(`Styles from the same Block may not be composed together.`, sourceRange(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`Styles from the same Block may not be composed together.`, sourceRange(configuration, root, sourceFile, decl));
       }
 
       const parsedSel = block.getParsedSelectors(rule);
       for (let sel of parsedSel) {
         if (sel.selector.next) {
-          throw new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a scope selector.`, sourceRange(sourceFile, decl));
+          throw new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a scope selector.`, sourceRange(configuration, root, sourceFile, decl));
         }
         let foundStyles = getStyleTargets(block, sel.selector);
         for (let blockClass of foundStyles.blockClasses) {

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -3,11 +3,11 @@ import { isRule } from "opticss/dist/src/util/cssIntrospection";
 
 import { COMPOSES } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
 import { getStyleTargets } from "../block-intermediates";
 import { stripQuotes } from "../utils";
-import { Configuration } from "../../configuration";
 
 /**
  * For each `composes` property found in the passed ruleset, track the foreign

--- a/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/construct-block.ts
@@ -38,14 +38,14 @@ function shouldBeParsedAsBlockSelector(rule: postcss.Rule): boolean {
  * @param file  string  The filepath of the file we are parsing for error reporting.
  * @returns The ParsedSelector array.
  **/
-function getParsedSelectors(block: Block, rule: postcss.Rule, file: string): ParsedSelector[] {
+function getParsedSelectors(configuration: Configuration, block: Block, rule: postcss.Rule, file: string): ParsedSelector[] {
   let res;
   try { res = block.getParsedSelectors(rule); }
-  catch (e) { throw new errors.InvalidBlockSyntax(e.message, sourceRange(file, rule)); }
+  catch (e) { throw new errors.InvalidBlockSyntax(e.message, sourceRange(configuration, block.stylesheet, file, rule)); }
   return res;
 }
 
-export async function constructBlock(root: postcss.Root, block: Block, configuration: Configuration, file: string): Promise<Block> {
+export async function constructBlock(configuration: Configuration, root: postcss.Root, block: Block, file: string): Promise<Block> {
 
   let styleRuleTuples: Set<[Style, postcss.Rule]> = new Set();
 
@@ -56,7 +56,7 @@ export async function constructBlock(root: postcss.Root, block: Block, configura
     if (!shouldBeParsedAsBlockSelector(rule)) { return; }
 
     // Fetch the parsed selectors list. Throw a helpful error if we can't parse.
-    let parsedSelectors = getParsedSelectors(block, rule, file);
+    let parsedSelectors = getParsedSelectors(configuration, block, rule, file);
 
     // Iterate over the all selectors for this rule – one for each comma separated selector.
     parsedSelectors.forEach((iSel) => {
@@ -99,7 +99,7 @@ export async function constructBlock(root: postcss.Root, block: Block, configura
   // To allow self-referential block lookup when constructing ruleset concerns,
   // we need to run `addRuleset()` only *after* all Styles have been created.
   for (let [style, rule] of styleRuleTuples) {
-    style.rulesets.addRuleset(file, rule);
+    style.rulesets.addRuleset(configuration, file, rule);
   }
 
   return block;

--- a/packages/@css-blocks/core/src/BlockParser/features/disallow-important.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/disallow-important.ts
@@ -1,8 +1,8 @@
 import { postcss } from "opticss";
 
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
-import { Configuration } from "../../configuration";
 
 export async function disallowImportant(configuration: Configuration, root: postcss.Root, file: string): Promise<postcss.Root> {
   root.walkDecls((decl) => {

--- a/packages/@css-blocks/core/src/BlockParser/features/disallow-important.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/disallow-important.ts
@@ -1,7 +1,7 @@
 import { postcss } from "opticss";
 
 import * as errors from "../../errors";
-import { sourceLocation as loc } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 
 export async function disallowImportant(root: postcss.Root, file: string): Promise<postcss.Root> {
   root.walkDecls((decl) => {
@@ -10,7 +10,7 @@ export async function disallowImportant(root: postcss.Root, file: string): Promi
     if (decl.important) {
       throw new errors.InvalidBlockSyntax(
         `!important is not allowed for \`${decl.prop}\` in \`${(<postcss.Rule>decl.parent).selector}\``,
-        loc(file, decl),
+        sourceRange(file, decl),
       );
     }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/disallow-important.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/disallow-important.ts
@@ -2,15 +2,16 @@ import { postcss } from "opticss";
 
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
+import { Configuration } from "../../configuration";
 
-export async function disallowImportant(root: postcss.Root, file: string): Promise<postcss.Root> {
+export async function disallowImportant(configuration: Configuration, root: postcss.Root, file: string): Promise<postcss.Root> {
   root.walkDecls((decl) => {
 
     // `!important` is not allowed in Blocks. If contains `!important` declaration, throw.
     if (decl.important) {
       throw new errors.InvalidBlockSyntax(
         `!important is not allowed for \`${decl.prop}\` in \`${(<postcss.Rule>decl.parent).selector}\``,
-        sourceRange(file, decl),
+        sourceRange(configuration, root, file, decl),
       );
     }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
@@ -2,7 +2,7 @@ import { postcss } from "opticss";
 
 import { BLOCK_NAME, CLASS_NAME_IDENT } from "../../BlockSyntax";
 import * as errors from "../../errors";
-import { sourceLocation } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 
 export async function discoverName(root: postcss.Root, defaultName: string, file: string): Promise<string> {
 
@@ -12,7 +12,7 @@ export async function discoverName(root: postcss.Root, defaultName: string, file
       if (!CLASS_NAME_IDENT.test(decl.value)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name. '${decl.value}' is not a legal CSS identifier.`,
-          sourceLocation(file, decl),
+          sourceRange(file, decl),
         );
       }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
@@ -3,8 +3,9 @@ import { postcss } from "opticss";
 import { BLOCK_NAME, CLASS_NAME_IDENT } from "../../BlockSyntax";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
+import { Configuration } from "../../configuration";
 
-export async function discoverName(root: postcss.Root, defaultName: string, file: string): Promise<string> {
+export async function discoverName(configuration: Configuration, root: postcss.Root, defaultName: string, file: string): Promise<string> {
 
   // Eagerly fetch custom `block-name` from the root block rule.
   root.walkRules(":scope", (rule) => {
@@ -12,7 +13,7 @@ export async function discoverName(root: postcss.Root, defaultName: string, file
       if (!CLASS_NAME_IDENT.test(decl.value)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name. '${decl.value}' is not a legal CSS identifier.`,
-          sourceRange(file, decl),
+          sourceRange(configuration, root, file, decl),
         );
       }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
@@ -1,9 +1,9 @@
 import { postcss } from "opticss";
 
 import { BLOCK_NAME, CLASS_NAME_IDENT } from "../../BlockSyntax";
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
-import { Configuration } from "../../configuration";
 
 export async function discoverName(configuration: Configuration, root: postcss.Root, defaultName: string, file: string): Promise<string> {
 

--- a/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
@@ -3,7 +3,7 @@ import { postcss } from "opticss";
 import { BLOCK_EXPORT, CLASS_NAME_IDENT, DEFAULT_EXPORT } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { sourceLocation } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 import { BlockFactory } from "../index";
 import { parseBlockNames, stripQuotes } from "../utils";
 
@@ -38,7 +38,7 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
     if (!exportList) {
       throw new errors.InvalidBlockSyntax(
         `Malformed block export: \`@export ${atRule.params}\``,
-        sourceLocation(file, atRule),
+        sourceRange(file, atRule),
       );
     }
 
@@ -55,32 +55,32 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
         if (remoteNames.has(remoteName)) {
         throw new errors.InvalidBlockSyntax(
           `Can not have duplicate Block export of same name: "${remoteName}".`,
-          sourceLocation(file, atRule),
+          sourceRange(file, atRule),
           );
         }
         let localName = blockNames[remoteName];
         if (!CLASS_NAME_IDENT.test(localName)) {
           throw new errors.InvalidBlockSyntax(
             `Illegal block name in export. "${localName}" is not a legal CSS identifier.`,
-            sourceLocation(file, atRule),
+            sourceRange(file, atRule),
           );
         }
         if (!CLASS_NAME_IDENT.test(remoteName)) {
           throw new errors.InvalidBlockSyntax(
             `Illegal block name in import. "${remoteName}" is not a legal CSS identifier.`,
-            sourceLocation(file, atRule),
+            sourceRange(file, atRule),
           );
         }
         if (localName === DEFAULT_EXPORT && remoteName === DEFAULT_EXPORT) {
           throw new errors.InvalidBlockSyntax(
             `Unnecessary re-export of default Block.`,
-            sourceLocation(file, atRule),
+            sourceRange(file, atRule),
           );
         }
         if (remoteName === DEFAULT_EXPORT) {
           throw new errors.InvalidBlockSyntax(
             `Can not export "${localName}" as reserved word "${DEFAULT_EXPORT}"`,
-            sourceLocation(file, atRule),
+            sourceRange(file, atRule),
           );
         }
 
@@ -88,7 +88,7 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
         if (!referencedBlock) {
           throw new errors.InvalidBlockSyntax(
             `Can not export Block "${localName}". No Block named "${localName}" in "${file}".`,
-            sourceLocation(file, atRule),
+            sourceRange(file, atRule),
           );
         }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
@@ -38,7 +38,7 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
     if (!exportList) {
       throw new errors.InvalidBlockSyntax(
         `Malformed block export: \`@export ${atRule.params}\``,
-        sourceRange(file, atRule),
+        sourceRange(factory.configuration, block.stylesheet, file, atRule),
       );
     }
 
@@ -55,32 +55,32 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
         if (remoteNames.has(remoteName)) {
         throw new errors.InvalidBlockSyntax(
           `Can not have duplicate Block export of same name: "${remoteName}".`,
-          sourceRange(file, atRule),
+          sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
         let localName = blockNames[remoteName];
         if (!CLASS_NAME_IDENT.test(localName)) {
           throw new errors.InvalidBlockSyntax(
             `Illegal block name in export. "${localName}" is not a legal CSS identifier.`,
-            sourceRange(file, atRule),
+            sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
         if (!CLASS_NAME_IDENT.test(remoteName)) {
           throw new errors.InvalidBlockSyntax(
             `Illegal block name in import. "${remoteName}" is not a legal CSS identifier.`,
-            sourceRange(file, atRule),
+            sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
         if (localName === DEFAULT_EXPORT && remoteName === DEFAULT_EXPORT) {
           throw new errors.InvalidBlockSyntax(
             `Unnecessary re-export of default Block.`,
-            sourceRange(file, atRule),
+            sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
         if (remoteName === DEFAULT_EXPORT) {
           throw new errors.InvalidBlockSyntax(
             `Can not export "${localName}" as reserved word "${DEFAULT_EXPORT}"`,
-            sourceRange(file, atRule),
+            sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
 
@@ -88,7 +88,7 @@ export async function exportBlocks(block: Block, factory: BlockFactory, file: st
         if (!referencedBlock) {
           throw new errors.InvalidBlockSyntax(
             `Can not export Block "${localName}". No Block named "${localName}" in "${file}".`,
-            sourceRange(file, atRule),
+            sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
 

--- a/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
@@ -2,9 +2,9 @@ import { postcss } from "opticss";
 
 import { EXTENDS } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
-import { Configuration } from "../../configuration";
 
 /**
  * For each `extends` property found in the passed ruleset, set the block's base

--- a/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
@@ -4,22 +4,23 @@ import { EXTENDS } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
+import { Configuration } from "../../configuration";
 
 /**
  * For each `extends` property found in the passed ruleset, set the block's base
  * to the foreign block. If block is not found, throw.
  * @param block  Block object being processed.
  * @param sourceFile  Source file name, used for error output.
- * @param rule Ruleset to crawl.
+ * @param root Ruleset to crawl.
  */
-export async function extendBlock(rule: postcss.Root, block: Block, sourceFile: string) {
-  rule.walkDecls(EXTENDS, (decl) => {
+export async function extendBlock(configuration: Configuration, root: postcss.Root, block: Block, sourceFile: string) {
+  root.walkDecls(EXTENDS, (decl) => {
     if (block.base) {
-      throw new errors.InvalidBlockSyntax(`A block can only be extended once.`, sourceRange(sourceFile, decl));
+      throw new errors.InvalidBlockSyntax(`A block can only be extended once.`, sourceRange(configuration, root, sourceFile, decl));
     }
     let baseBlock = block.getReferencedBlock(decl.value);
     if (!baseBlock) {
-      throw new errors.InvalidBlockSyntax(`No Block named "${decl.value}" found in scope.`, sourceRange(sourceFile, decl));
+      throw new errors.InvalidBlockSyntax(`No Block named "${decl.value}" found in scope.`, sourceRange(configuration, root, sourceFile, decl));
     }
     block.setBase(baseBlock);
   });

--- a/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/extend-block.ts
@@ -3,7 +3,7 @@ import { postcss } from "opticss";
 import { EXTENDS } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { sourceLocation } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 
 /**
  * For each `extends` property found in the passed ruleset, set the block's base
@@ -15,11 +15,11 @@ import { sourceLocation } from "../../SourceLocation";
 export async function extendBlock(rule: postcss.Root, block: Block, sourceFile: string) {
   rule.walkDecls(EXTENDS, (decl) => {
     if (block.base) {
-      throw new errors.InvalidBlockSyntax(`A block can only be extended once.`, sourceLocation(sourceFile, decl));
+      throw new errors.InvalidBlockSyntax(`A block can only be extended once.`, sourceRange(sourceFile, decl));
     }
     let baseBlock = block.getReferencedBlock(decl.value);
     if (!baseBlock) {
-      throw new errors.InvalidBlockSyntax(`No Block named "${decl.value}" found in scope.`, sourceLocation(sourceFile, decl));
+      throw new errors.InvalidBlockSyntax(`No Block named "${decl.value}" found in scope.`, sourceRange(sourceFile, decl));
     }
     block.setBase(baseBlock);
   });

--- a/packages/@css-blocks/core/src/BlockParser/features/global-attributes.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/global-attributes.ts
@@ -3,7 +3,7 @@ import { parseSelector, postcss, postcssSelectorParser as selectorParser } from 
 import { BLOCK_GLOBAL } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { sourceLocation as loc } from "../../SourceLocation";
+import { sourceRange as range } from "../../SourceLocation";
 import { toAttrToken } from "../block-intermediates";
 
 export async function globalAttributes(root: postcss.Root, block: Block, file: string): Promise<Block> {
@@ -22,7 +22,7 @@ export async function globalAttributes(root: postcss.Root, block: Block, file: s
       } else {
         throw new errors.InvalidBlockSyntax(
           `Illegal global attribute declaration: ${atRule.toString()}`,
-          loc(file, atRule),
+          range(file, atRule),
         );
       }
     }

--- a/packages/@css-blocks/core/src/BlockParser/features/global-attributes.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/global-attributes.ts
@@ -5,8 +5,9 @@ import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
 import { sourceRange as range } from "../../SourceLocation";
 import { toAttrToken } from "../block-intermediates";
+import { Configuration } from "../../configuration";
 
-export async function globalAttributes(root: postcss.Root, block: Block, file: string): Promise<Block> {
+export async function globalAttributes(configuration: Configuration, root: postcss.Root, block: Block, file: string): Promise<Block> {
   root.walkAtRules(BLOCK_GLOBAL, (atRule) => {
 
     let selectors = parseSelector(atRule.params.trim());
@@ -22,7 +23,7 @@ export async function globalAttributes(root: postcss.Root, block: Block, file: s
       } else {
         throw new errors.InvalidBlockSyntax(
           `Illegal global attribute declaration: ${atRule.toString()}`,
-          range(file, atRule),
+          range(configuration, root, file, atRule),
         );
       }
     }

--- a/packages/@css-blocks/core/src/BlockParser/features/global-attributes.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/global-attributes.ts
@@ -2,10 +2,10 @@ import { parseSelector, postcss, postcssSelectorParser as selectorParser } from 
 
 import { BLOCK_GLOBAL } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange as range } from "../../SourceLocation";
 import { toAttrToken } from "../block-intermediates";
-import { Configuration } from "../../configuration";
 
 export async function globalAttributes(configuration: Configuration, root: postcss.Root, block: Block, file: string): Promise<Block> {
   root.walkAtRules(BLOCK_GLOBAL, (atRule) => {

--- a/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
@@ -2,9 +2,9 @@ import { postcss } from "opticss";
 
 import { IMPLEMENTS } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
+import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
-import { Configuration } from "../../configuration";
 
 /**
  * For each `implements` property found in the passed ruleset, track the foreign

--- a/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
@@ -4,6 +4,7 @@ import { IMPLEMENTS } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
+import { Configuration } from "../../configuration";
 
 /**
  * For each `implements` property found in the passed ruleset, track the foreign
@@ -12,13 +13,13 @@ import { sourceRange } from "../../SourceLocation";
  * @param sourceFile  Source file name, used for error output.
  * @param rule Ruleset to crawl
  */
-export async function implementBlock(rule: postcss.Root, block: Block, sourceFile: string) {
+export async function implementBlock(configuration: Configuration, rule: postcss.Root, block: Block, sourceFile: string) {
   rule.walkDecls(IMPLEMENTS, (decl) => {
     let refNames = decl.value.split(/,\s*/);
     refNames.forEach((refName) => {
       let refBlock = block.getReferencedBlock(refName);
       if (!refBlock) {
-        throw new errors.InvalidBlockSyntax(`No Block named "${refName}" found in scope.`, sourceRange(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`No Block named "${refName}" found in scope.`, sourceRange(configuration, block.stylesheet, sourceFile, decl));
       }
       block.addImplementation(refBlock);
     });

--- a/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/implement-block.ts
@@ -3,7 +3,7 @@ import { postcss } from "opticss";
 import { IMPLEMENTS } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { sourceLocation } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 
 /**
  * For each `implements` property found in the passed ruleset, track the foreign
@@ -18,7 +18,7 @@ export async function implementBlock(rule: postcss.Root, block: Block, sourceFil
     refNames.forEach((refName) => {
       let refBlock = block.getReferencedBlock(refName);
       if (!refBlock) {
-        throw new errors.InvalidBlockSyntax(`No Block named "${refName}" found in scope.`, sourceLocation(sourceFile, decl));
+        throw new errors.InvalidBlockSyntax(`No Block named "${refName}" found in scope.`, sourceRange(sourceFile, decl));
       }
       block.addImplementation(refBlock);
     });

--- a/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
@@ -37,7 +37,7 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
     if (!blockList || !blockPath) {
       throw new errors.InvalidBlockSyntax(
         `Malformed block reference: \`@block ${atRule.params}\``,
-        sourceRange(file, atRule),
+        sourceRange(factory.configuration, block.stylesheet, file, atRule),
         );
       }
 
@@ -51,25 +51,25 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
       if (!CLASS_NAME_IDENT.test(localName)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name in import. "${localName}" is not a legal CSS identifier.`,
-          sourceRange(file, atRule),
+          sourceRange(factory.configuration, block.stylesheet, file, atRule),
         );
       }
       if (!CLASS_NAME_IDENT.test(remoteName)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name in import. "${remoteName}" is not a legal CSS identifier.`,
-          sourceRange(file, atRule),
+          sourceRange(factory.configuration, block.stylesheet, file, atRule),
         );
       }
       if (localName === DEFAULT_EXPORT && remoteName === DEFAULT_EXPORT) {
         throw new errors.InvalidBlockSyntax(
           `Default Block from "${blockPath}" must be aliased to a unique local identifier.`,
-          sourceRange(file, atRule),
+          sourceRange(factory.configuration, block.stylesheet, file, atRule),
         );
       }
       if (localName === DEFAULT_EXPORT) {
         throw new errors.InvalidBlockSyntax(
           `Can not import "${remoteName}" as reserved word "${DEFAULT_EXPORT}"`,
-          sourceRange(file, atRule),
+          sourceRange(factory.configuration, block.stylesheet, file, atRule),
         );
       }
 
@@ -79,7 +79,7 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
         if (!referencedBlock) {
           throw new errors.InvalidBlockSyntax(
             `Can not import Block "${remoteName}". No Block named "${remoteName}" exported by "${blockPath}".`,
-            sourceRange(file, atRule),
+            sourceRange(factory.configuration, block.stylesheet, file, atRule),
           );
         }
         return [localName, blockPath, atRule, referencedBlock];
@@ -96,7 +96,7 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
     if (localNames[localName]) {
       throw new errors.InvalidBlockSyntax(
         `Blocks ${localNames[localName]} and ${importPath} cannot both have the name ${localName} in this scope.`,
-        sourceRange(file, atRule),
+        sourceRange(factory.configuration, block.stylesheet, file, atRule),
       );
     } else {
       block.addBlockReference(localName, otherBlock);

--- a/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
@@ -4,7 +4,7 @@ import { postcss } from "opticss";
 import { BLOCK_IMPORT, CLASS_NAME_IDENT, DEFAULT_EXPORT } from "../../BlockSyntax";
 import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
-import { sourceLocation } from "../../SourceLocation";
+import { sourceRange } from "../../SourceLocation";
 import { BlockFactory } from "../index";
 import { parseBlockNames, stripQuotes } from "../utils";
 
@@ -37,7 +37,7 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
     if (!blockList || !blockPath) {
       throw new errors.InvalidBlockSyntax(
         `Malformed block reference: \`@block ${atRule.params}\``,
-        sourceLocation(file, atRule),
+        sourceRange(file, atRule),
         );
       }
 
@@ -51,25 +51,25 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
       if (!CLASS_NAME_IDENT.test(localName)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name in import. "${localName}" is not a legal CSS identifier.`,
-          sourceLocation(file, atRule),
+          sourceRange(file, atRule),
         );
       }
       if (!CLASS_NAME_IDENT.test(remoteName)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name in import. "${remoteName}" is not a legal CSS identifier.`,
-          sourceLocation(file, atRule),
+          sourceRange(file, atRule),
         );
       }
       if (localName === DEFAULT_EXPORT && remoteName === DEFAULT_EXPORT) {
         throw new errors.InvalidBlockSyntax(
           `Default Block from "${blockPath}" must be aliased to a unique local identifier.`,
-          sourceLocation(file, atRule),
+          sourceRange(file, atRule),
         );
       }
       if (localName === DEFAULT_EXPORT) {
         throw new errors.InvalidBlockSyntax(
           `Can not import "${remoteName}" as reserved word "${DEFAULT_EXPORT}"`,
-          sourceLocation(file, atRule),
+          sourceRange(file, atRule),
         );
       }
 
@@ -79,7 +79,7 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
         if (!referencedBlock) {
           throw new errors.InvalidBlockSyntax(
             `Can not import Block "${remoteName}". No Block named "${remoteName}" exported by "${blockPath}".`,
-            sourceLocation(file, atRule),
+            sourceRange(file, atRule),
           );
         }
         return [localName, blockPath, atRule, referencedBlock];
@@ -96,7 +96,7 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
     if (localNames[localName]) {
       throw new errors.InvalidBlockSyntax(
         `Blocks ${localNames[localName]} and ${importPath} cannot both have the name ${localName} in this scope.`,
-        sourceLocation(file, atRule),
+        sourceRange(file, atRule),
       );
     } else {
       block.addBlockReference(localName, otherBlock);

--- a/packages/@css-blocks/core/src/BlockParser/features/process-debug-statements.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/process-debug-statements.ts
@@ -13,7 +13,7 @@ import { ResolvedConfiguration } from "../../configuration";
  */
 export async function processDebugStatements(root: postcss.Root, block: Block, file: string, config: ResolvedConfiguration) {
   root.walkAtRules(BLOCK_DEBUG, (atRule) => {
-    let { block: ref, channel } = parseBlockDebug(atRule, file, block);
+    let { block: ref, channel } = parseBlockDebug(config, root, atRule, file, block);
     let debugStr = ref.debug(config);
     if (channel !== "comment") {
       if (channel === "stderr") {

--- a/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
@@ -1,4 +1,4 @@
-import { BlockPathError, ErrorLocation, Position, hasErrorPosition } from "../errors";
+import { BlockPathError, ErrorLocation, Position, errorHasRange } from "../errors";
 
 import {
   ATTR_PRESENT,
@@ -137,7 +137,7 @@ export class BlockPath {
     let end: Position | undefined;
     if (this._location) {
       filename = this._location.filename;
-      if (hasErrorPosition(this._location)) {
+      if (errorHasRange(this._location)) {
         start = { ...this._location.start };
         end = { ...this._location.end };
       } else {

--- a/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
@@ -147,6 +147,7 @@ export class BlockPath {
       end.column = start.column + this.walker.index();
       start.column = start.column + this.walker.index() - len;
     }
+    // TODO: Add sourcemap handling.
     throw new BlockPathError(msg, {filename, start, end});
   }
 

--- a/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/BlockPath.ts
@@ -141,7 +141,6 @@ export class BlockPath {
         start = { ...this._location.start };
         end = { ...this._location.end };
       } else {
-        console.dir(this._location);
         start = { column: 0, line: 1 };
         end = { column: 0, line: 1 };
       }

--- a/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
@@ -3,17 +3,18 @@ import { postcss } from "opticss";
 import { Block } from "../BlockTree";
 import * as errors from "../errors";
 import { sourceRange } from "../SourceLocation";
+import { Configuration } from "../configuration";
 
 export type DebugChannel = "comment" | "stderr" | "stdout";
 
-export function parseBlockDebug(atRule: postcss.AtRule, sourceFile: string, scope: Block): { block: Block; channel: DebugChannel } {
+export function parseBlockDebug(configuration: Configuration, root: postcss.Root, atRule: postcss.AtRule, sourceFile: string, scope: Block): { block: Block; channel: DebugChannel } {
 
   let md = atRule.params.match(/([^\s]+) to (comment|stderr|stdout)/);
 
   if (!md) {
     throw new errors.InvalidBlockSyntax(
       `Malformed block debug: \`@block-debug ${atRule.params}\``,
-      sourceRange(sourceFile, atRule));
+      sourceRange(configuration, root, sourceFile, atRule));
   }
 
   let localName = md[1];
@@ -27,7 +28,7 @@ export function parseBlockDebug(atRule: postcss.AtRule, sourceFile: string, scop
   if (!block) {
     throw new errors.InvalidBlockSyntax(
       `Invalid block debug: No Block named "${localName}" found in scope.`,
-      sourceRange(sourceFile, atRule));
+      sourceRange(configuration, root, sourceFile, atRule));
   }
 
   return { block, channel };

--- a/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
@@ -2,7 +2,7 @@ import { postcss } from "opticss";
 
 import { Block } from "../BlockTree";
 import * as errors from "../errors";
-import { sourceLocation } from "../SourceLocation";
+import { sourceRange } from "../SourceLocation";
 
 export type DebugChannel = "comment" | "stderr" | "stdout";
 
@@ -13,7 +13,7 @@ export function parseBlockDebug(atRule: postcss.AtRule, sourceFile: string, scop
   if (!md) {
     throw new errors.InvalidBlockSyntax(
       `Malformed block debug: \`@block-debug ${atRule.params}\``,
-      sourceLocation(sourceFile, atRule));
+      sourceRange(sourceFile, atRule));
   }
 
   let localName = md[1];
@@ -27,7 +27,7 @@ export function parseBlockDebug(atRule: postcss.AtRule, sourceFile: string, scop
   if (!block) {
     throw new errors.InvalidBlockSyntax(
       `Invalid block debug: No Block named "${localName}" found in scope.`,
-      sourceLocation(sourceFile, atRule));
+      sourceRange(sourceFile, atRule));
   }
 
   return { block, channel };

--- a/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
+++ b/packages/@css-blocks/core/src/BlockSyntax/parseBlockDebug.ts
@@ -1,9 +1,9 @@
 import { postcss } from "opticss";
 
 import { Block } from "../BlockTree";
+import { Configuration } from "../configuration";
 import * as errors from "../errors";
 import { sourceRange } from "../SourceLocation";
-import { Configuration } from "../configuration";
 
 export type DebugChannel = "comment" | "stderr" | "stdout";
 

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -14,7 +14,7 @@ import { BlockPath, CLASS_NAME_IDENT, DEFAULT_EXPORT, ROOT_CLASS } from "../Bloc
 import { ResolvedConfiguration } from "../configuration";
 import { CssBlockError, InvalidBlockSyntax } from "../errors";
 import { FileIdentifier } from "../importing";
-import { SourceLocation } from "../SourceLocation";
+import { SourceFile, SourceRange } from "../SourceLocation";
 
 import { BlockClass } from "./BlockClass";
 import { Inheritable } from "./Inheritable";
@@ -116,7 +116,7 @@ export class Block
    *   A single dot by itself returns the current block.
    * @returns The Style referenced at the supplied path.
    */
-  public lookup(path: string | BlockPath, errLoc?: SourceLocation): Styles | undefined {
+  public lookup(path: string | BlockPath, errLoc?: SourceRange | SourceFile): Styles | undefined {
     path = new BlockPath(path);
     let block = this.getReferencedBlock(path.block);
     if (!block) {

--- a/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
+++ b/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
@@ -11,7 +11,7 @@ import { ParsedSelector, postcss } from "opticss";
 
 import { BLOCK_PROP_NAMES, SELF_SELECTOR, getResolution } from "../BlockSyntax";
 import { InvalidBlockSyntax } from "../errors";
-import { sourceLocation } from "../SourceLocation";
+import { sourceRange } from "../SourceLocation";
 import { expandProp } from "../util/propertyParser";
 
 import { Styles, isStyle } from "./Styles";
@@ -115,7 +115,7 @@ export class RulesetContainer<S extends Styles> {
         // If this is a resolution, track that this property has been resolved
         // Resolution paths are always relative to the root node.
         if (resolution.path) {
-          let errLoc = sourceLocation(file, decl);
+          let errLoc = sourceRange(file, decl);
           let other = style.block.lookup(resolution.path, errLoc);
 
           if (other && other.block === style.block) {

--- a/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
+++ b/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
@@ -10,12 +10,12 @@ import { MultiMap, TwoKeyMultiMap } from "@opticss/util";
 import { ParsedSelector, postcss } from "opticss";
 
 import { BLOCK_PROP_NAMES, SELF_SELECTOR, getResolution } from "../BlockSyntax";
+import { Configuration } from "../configuration";
 import { InvalidBlockSyntax } from "../errors";
 import { sourceRange } from "../SourceLocation";
 import { expandProp } from "../util/propertyParser";
 
 import { Styles, isStyle } from "./Styles";
-import { Configuration } from "../configuration";
 export { Styles, BlockClass, AttrValue } from "./Styles";
 
 // Convenience types to help our code read better.

--- a/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
+++ b/packages/@css-blocks/core/src/BlockTree/RulesetContainer.ts
@@ -15,6 +15,7 @@ import { sourceRange } from "../SourceLocation";
 import { expandProp } from "../util/propertyParser";
 
 import { Styles, isStyle } from "./Styles";
+import { Configuration } from "../configuration";
 export { Styles, BlockClass, AttrValue } from "./Styles";
 
 // Convenience types to help our code read better.
@@ -95,7 +96,7 @@ export class RulesetContainer<S extends Styles> {
    * @param  rule  PostCSS ruleset
    * @param  block  External block
    */
-  addRuleset(file: string, rule: postcss.Rule) {
+  addRuleset(configuration: Configuration, file: string, rule: postcss.Rule) {
     let style = this.parent;
     let selectors: ParsedSelector[] = style.getParsedSelectors(rule);
 
@@ -115,7 +116,7 @@ export class RulesetContainer<S extends Styles> {
         // If this is a resolution, track that this property has been resolved
         // Resolution paths are always relative to the root node.
         if (resolution.path) {
-          let errLoc = sourceRange(file, decl);
+          let errLoc = sourceRange(configuration, style.block.stylesheet, file, decl);
           let other = style.block.lookup(resolution.path, errLoc);
 
           if (other && other.block === style.block) {

--- a/packages/@css-blocks/core/src/SourceLocation.ts
+++ b/packages/@css-blocks/core/src/SourceLocation.ts
@@ -194,10 +194,3 @@ function isGreaterPosition(p1: SourcePosition, p2: SourcePosition): boolean {
   return p1.line === p2.line && p1.column > p2.column
       || p1.line > p2.line;
 }
-
-// function samePosition(p1: NullableMappedPosition, p2: NullableMappedPosition): boolean {
-//   return p1.column === p2.column &&
-//          p1.line === p2.line &&
-//          p1.source === p2.source &&
-//          p1.name === p2.name;
-// }

--- a/packages/@css-blocks/core/src/SourceLocation.ts
+++ b/packages/@css-blocks/core/src/SourceLocation.ts
@@ -1,7 +1,20 @@
 import { postcss, postcssSelectorParser as selectorParser } from "opticss";
+import * as path from "path";
+import { MappedPosition, SourceMapConsumer } from "source-map";
 
+import { Configuration } from "./configuration";
+
+/**
+ * Represents a character.
+ */
 export interface SourcePosition {
+  /**
+   * 1-based index of the line containing the character.
+   */
   line: number;
+  /**
+   * 1-based index of the column containing the character.
+   */
   column: number;
 }
 export interface SourceFile {
@@ -10,9 +23,29 @@ export interface SourceFile {
 
 export type SourceLocation = Partial<SourceFile> & SourcePosition;
 
+/**
+ * Represents a text range in a file.
+ * The range is inclusive of both the start and end characters,
+ * so a range of a single character will have the same value for the
+ * start and the end positions.
+ */
 export interface SourceRange extends Partial<SourceFile> {
   start: SourcePosition;
   end: SourcePosition;
+}
+
+/**
+ * Represents the source range with additional range information that spans the
+ * same location in the output from compiling that source.
+ *
+ * Because we use the source map to work backwards from the generated output,
+ * the range information as it applies to the generated source is more accurate,
+ * but also less actionable.
+ */
+export interface MappedSourceRange extends Required<SourceRange> {
+  generated: Required<SourceRange> & {
+    source: string;
+  };
 }
 
 /**
@@ -26,11 +59,11 @@ export function addSourcePositions(...locations: SourcePosition[]) {
     if (o.line === 1) {
       return {
         line: l.line,
-        column: l.column + o.column - 1,
+        column: l.column + o.column - 1, // -1 because 1-based index math
       };
     } else {
       return {
-        line: l.line + o.line - 1,
+        line: l.line + o.line - 1, // -1 because 1-based index math
         column: o.column,
       };
     }
@@ -57,19 +90,33 @@ export function sourceRange(filename: string, node: postcss.Node): SourceRange |
   }
 }
 
+const CSS_CONTENT_CACHE = new WeakMap();
+
 /**
- * Logging utility function to fetch the filename, line number and column number
+ * Utility function to fetch the filename, line number and column number
  * of a given selector.
  * @param filename  The source file name that contains this rule.
  * @param rule  The PostCSS Rule object containing this selector.
  * @param selector  The PostCSS selector node in question.
  * @returns An object representing the filename, line number and column number.
  */
-export function selectorSourceRange(filename: string, rule: postcss.Rule, selector: selectorParser.Node): SourceRange | SourceFile {
+export function selectorSourceRange(configuration: Configuration, root: postcss.Root | null | undefined, filename: string, rule: postcss.Rule, selector: selectorParser.Node): SourceRange | SourceFile | MappedSourceRange {
   if (rule.source && rule.source.start && rule.source.end &&
       selector.source && selector.source.start && selector.source.end) {
     let start = addSourcePositions(rule.source.start, selector.source.start);
     let end = addSourcePositions(rule.source.start, selector.source.end);
+    // try to trace the error back to the source file using sourcemap information.
+    if (root && root.source && root.source.input.map) {
+      let consumer = root.source.input.map.consumer();
+      // the original result text isn't easy to get at from here,
+      // so we're using the stringified version and caching it.
+      let source = CSS_CONTENT_CACHE.get(root);
+      if (!source) {
+        source = root.toResult().css;
+        CSS_CONTENT_CACHE.set(root, source);
+      }
+      return pickBestSourceRange(configuration, filename, source, consumer, start, end);
+    }
     return {
       filename,
       start,
@@ -78,3 +125,80 @@ export function selectorSourceRange(filename: string, rule: postcss.Rule, select
   }
   return { filename };
 }
+
+/**
+ * The type actually allows null values for all these properties.
+ */
+type NullableMappedPosition  = {
+  [key in keyof MappedPosition]: MappedPosition[key] | null;
+};
+
+/**
+ * Source mapping to the right location is a bit of an art and is highly
+ * dependent on how the underlying language implementation maps bytes. This
+ * function is basically a heuristic that tries to give back the best possible
+ * source range for the generated range.
+ *
+ * Because it's not always accurate, it also returns the generated source and
+ * location so that context can be used as well.
+ */
+function pickBestSourceRange(configuration: Configuration, filename: string, source: string, consumer: ReturnType<postcss.PreviousMap["consumer"]> , start: SourcePosition, end: SourcePosition): MappedSourceRange | SourceRange {
+  let generated = { filename, start, end, source };
+  // Fun fact! The positions returned by the source map consumer use a 1-based
+  // index for lines, and a 0-based index for columns.
+  let startOrigin: NullableMappedPosition = consumer.originalPositionFor({ line: start.line, column: start.column - 1, bias: SourceMapConsumer.LEAST_UPPER_BOUND});
+  let endOrigin: NullableMappedPosition = consumer.originalPositionFor({ line: end.line, column: end.column - 1, bias: SourceMapConsumer.LEAST_UPPER_BOUND});
+  // If the start and end locations of the origins are in different files,
+  // we try different biases to see if we can get something that agrees.
+  if (startOrigin.source && startOrigin.source !== endOrigin.source) {
+    let startOrigin2: NullableMappedPosition = consumer.originalPositionFor({ line: start.line, column: start.column - 1, bias: SourceMapConsumer.GREATEST_LOWER_BOUND });
+    let endOrigin2: NullableMappedPosition = consumer.originalPositionFor({ line: end.line, column: end.column - 1, bias: SourceMapConsumer.GREATEST_LOWER_BOUND });
+    if (startOrigin2.source && startOrigin2.source === endOrigin.source) {
+      startOrigin = startOrigin2;
+    } else if (endOrigin2.source && startOrigin.source === endOrigin2.source) {
+      endOrigin = endOrigin2;
+    } else if (startOrigin2.source && endOrigin2.source && startOrigin2.source === endOrigin2.source) {
+      startOrigin = startOrigin2;
+      endOrigin = endOrigin2;
+    } else if (startOrigin.line !== null && startOrigin.column !== null) {
+      // pick the starting file's location and add a character.
+      endOrigin = { ...startOrigin, ...{ column: startOrigin.column + 1 } };
+    } else if (endOrigin.line !== null && endOrigin.column !== null && endOrigin.column > 0) {
+      // pick the ending file's location and remove a character.
+      startOrigin = { ...endOrigin, ...{ column: endOrigin.column - 1 } };
+    } else {
+      // I don't think we'll get here
+      return { filename, start, end };
+    }
+  }
+  if (startOrigin.source && endOrigin.source && startOrigin.source === endOrigin.source) {
+    if (startOrigin.line !== null && startOrigin.column !== null &&
+        endOrigin.line !== null && endOrigin.column !== null) {
+      filename = path.resolve(configuration.rootDir, filename, startOrigin.source);
+      // column+1 to translate to our 1-based index for columns
+      start = { line: startOrigin.line, column: startOrigin.column + 1 };
+      end = { line: endOrigin.line, column: endOrigin.column + 1 };
+      // There must be an off-by-one error... somewhere.
+      // Subtracting 1 here seems to work but I don't have a good reason for it.
+      if (isGreaterPosition(end, start)) {
+        end.column = end.column - 1;
+      }
+    }
+  }
+  return { filename, start, end, generated };
+}
+
+/**
+ * Returns true if p1 comes after the position p2.
+ */
+function isGreaterPosition(p1: SourcePosition, p2: SourcePosition): boolean {
+  return p1.line === p2.line && p1.column > p2.column
+      || p1.line > p2.line;
+}
+
+// function samePosition(p1: NullableMappedPosition, p2: NullableMappedPosition): boolean {
+//   return p1.column === p2.column &&
+//          p1.line === p2.line &&
+//          p1.source === p2.source &&
+//          p1.name === p2.name;
+// }

--- a/packages/@css-blocks/core/src/errors.ts
+++ b/packages/@css-blocks/core/src/errors.ts
@@ -39,7 +39,7 @@ export class CssBlockError extends Error {
     if (!loc) {
       return this.origMessage;
     }
-    let filename = loc.filename || "";
+    let filename = loc.filename || "<unknown file>";
     let line: string | number = "";
     let column: string | number = "";
     if (hasErrorPosition(loc)) {

--- a/packages/@css-blocks/core/src/errors.ts
+++ b/packages/@css-blocks/core/src/errors.ts
@@ -1,7 +1,22 @@
-export interface ErrorLocation {
+export interface Position {
+  line: number;
+  column: number;
+}
+
+export interface ErrorWithoutPosition {
   filename?: string;
-  line?: number;
-  column?: number;
+}
+
+export interface ErrorWithPosition {
+  filename: string;
+  start: Position;
+  end: Position;
+}
+
+export type ErrorLocation = ErrorWithoutPosition | ErrorWithPosition;
+
+export function hasErrorPosition(location: ErrorLocation | void): location is ErrorWithPosition {
+  return location && typeof (<ErrorWithPosition>location).start === "object" || false;
 }
 
 /**
@@ -25,8 +40,12 @@ export class CssBlockError extends Error {
       return this.origMessage;
     }
     let filename = loc.filename || "";
-    let line = loc.line ? `:${loc.line}` : "";
-    let column = loc.column ? `:${loc.column}` : "";
+    let line: string | number = "";
+    let column: string | number = "";
+    if (hasErrorPosition(loc)) {
+      line = `:${loc.start.line}`;
+      column = `:${loc.start.column}`;
+    }
     let locMessage = ` (${filename}${line}${column})`;
     // tslint:disable-next-line:prefer-unknown-to-any
     return `[css-blocks] ${(this.constructor as any).prefix}: ${this.origMessage}${locMessage}`;

--- a/packages/@css-blocks/core/src/errors.ts
+++ b/packages/@css-blocks/core/src/errors.ts
@@ -1,12 +1,10 @@
 import * as SourceLocation from "./SourceLocation";
+
+// TODO: Remove these types and use source location types everywhere.
 export type Position = SourceLocation.SourcePosition;
-
 export type ErrorWithoutPosition = Partial<SourceLocation.SourceFile>;
-
 export type ErrorWithPosition = Required<SourceLocation.SourceRange>;
-
 export type ErrorWithMappedPosition = SourceLocation.MappedSourceRange;
-
 export type ErrorLocation = ErrorWithoutPosition | ErrorWithPosition | ErrorWithMappedPosition;
 
 export function hasMappedPosition(loc: ErrorLocation): loc is ErrorWithMappedPosition {

--- a/packages/@css-blocks/core/src/errors.ts
+++ b/packages/@css-blocks/core/src/errors.ts
@@ -1,19 +1,17 @@
-export interface Position {
-  line: number;
-  column: number;
-}
+import * as SourceLocation from "./SourceLocation";
+export type Position = SourceLocation.SourcePosition;
 
-export interface ErrorWithoutPosition {
-  filename?: string;
-}
+export type ErrorWithoutPosition = Partial<SourceLocation.SourceFile>;
 
-export interface ErrorWithPosition {
-  filename: string;
-  start: Position;
-  end: Position;
-}
+export type ErrorWithPosition = Required<SourceLocation.SourceRange>;
 
-export type ErrorLocation = ErrorWithoutPosition | ErrorWithPosition;
+export type ErrorWithMappedPosition = SourceLocation.MappedSourceRange;
+
+export type ErrorLocation = ErrorWithoutPosition | ErrorWithPosition | ErrorWithMappedPosition;
+
+export function hasMappedPosition(loc: ErrorLocation): loc is ErrorWithMappedPosition {
+  return (typeof (<ErrorWithMappedPosition>loc).generated === "object");
+}
 
 export function hasErrorPosition(location: ErrorLocation | void): location is ErrorWithPosition {
   return location && typeof (<ErrorWithPosition>location).start === "object" || false;

--- a/packages/@css-blocks/core/test/Block/ruleset-container-test.ts
+++ b/packages/@css-blocks/core/test/Block/ruleset-container-test.ts
@@ -3,10 +3,12 @@ import { suite, test } from "mocha-typescript";
 import { postcss } from "opticss";
 
 import { Block } from "../../src";
+import { resolveConfiguration } from "../../src/configuration";
 
 @suite("Ruleset Containers")
 export class RulesetContainerTests {
   @test "addRuleset saves property concerns for multiple rulesets"() {
+    let config = resolveConfiguration({});
     let b = new Block("name", "filepath");
     let c = b.ensureClass("test");
     let rulesets = c.rulesets;
@@ -23,7 +25,7 @@ export class RulesetContainerTests {
       .baz::after {
         background: blue;
       }
-    `).walkRules(rulesets.addRuleset.bind(rulesets, "file.css"));
+    `).walkRules(rulesets.addRuleset.bind(rulesets, config, "file.css"));
 
     assert.deepEqual([...rulesets.getProperties()], ["display", "float", "color"]);
     assert.deepEqual([...rulesets.getProperties("::after")], ["background-color", "background"]);

--- a/packages/@css-blocks/core/test/BlockSyntax/block-path-test.ts
+++ b/packages/@css-blocks/core/test/BlockSyntax/block-path-test.ts
@@ -300,8 +300,14 @@ export class BlockPathTests {
   @test "unescaped illegal characters in identifiers throw."() {
     let loc = {
       filename: "foo.scss",
-      line: 10,
-      column: 20,
+      start: {
+        line: 10,
+        column: 20,
+      },
+      end: {
+        line: 10,
+        column: 21,
+      },
     };
     assert.throws(
       () => {

--- a/packages/@css-blocks/glimmer/package.json
+++ b/packages/@css-blocks/glimmer/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@css-blocks/code-style": "^0.23.0",
-    "@types/fs-extra": "^7.0.0",
+    "@types/fs-extra": "^8.0.0",
     "@types/glob": "^7.1.1",
     "watch": "^1.0.2"
   },

--- a/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
+++ b/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
@@ -4,6 +4,7 @@ import {
   BlockClass,
   ElementAnalysis,
   ResolvedConfiguration as CSSBlocksConfiguration,
+  charInFile,
 } from "@css-blocks/core";
 import { AST, print } from "@glimmer/syntax";
 import { SourceLocation, SourcePosition } from "@opticss/element-analysis";
@@ -68,7 +69,7 @@ export class ElementAnalyzer {
 
   private debugTemplateLocation(node: AnalyzableNodes) {
     let templatePath = this.cssBlocksOpts.importer.debugIdentifier(this.template.identifier, this.cssBlocksOpts);
-    return `${templatePath}:${node.loc.start.line}:${node.loc.start.column}`;
+    return charInFile(templatePath, node.loc.start);
   }
   private debugBlockPath() {
     return this.cssBlocksOpts.importer.debugIdentifier(this.block.identifier, this.cssBlocksOpts);

--- a/packages/@css-blocks/glimmer/src/utils.ts
+++ b/packages/@css-blocks/glimmer/src/utils.ts
@@ -31,7 +31,7 @@ export function parseSpecifier(specifier: string): { componentType: string; comp
 export function cssBlockError(message: string, node: AST.Node, template: TemplateInfo<TEMPLATE_TYPE>) {
   return new CssBlockError(message, {
     filename: node.loc.source || template.identifier,
-    line: node.loc.start.line,
-    column: node.loc.start.column,
+    start: node.loc.start,
+    end: node.loc.end,
   });
 }

--- a/packages/@css-blocks/jsx/src/transformer/babel.ts
+++ b/packages/@css-blocks/jsx/src/transformer/babel.ts
@@ -2,6 +2,7 @@ import {
   Analysis,
   ResolvedConfiguration as CSSBlocksConfiguration,
   StyleMapping,
+  charInFile,
 } from "@css-blocks/core";
 import { PluginObj } from "babel-core";
 import { NodePath } from "babel-traverse";
@@ -219,7 +220,7 @@ function detectStrayReferenceToImport(
           if (!filename.endsWith("x")) {
             console.warn(`WARNING: For performance reasons, only jsx and tsx files are properly analyzed for block dependencies and rewritten. Consider renaming ${filename} to ${filename}x as well as any leading to importing it from the entry point.`);
           }
-          console.warn(`WARNING: Stray reference to block import (${specifier.local.name}). Imports are removed during rewrite so this will probably be a runtime error. (${filename}:${ref.node.loc.start.line}:${ref.node.loc.start.column})`);
+          console.warn(`WARNING: Stray reference to block import (${specifier.local.name}). Imports are removed during rewrite so this will probably be a runtime error. (${charInFile(filename, ref.node.loc.start)})`);
           console.warn(`WARNING: This usually happens when a style reference is incorrectly used outside a jsx expression. But sometimes when an application is improperly configured. Be sure that only files ending in jsx or tsx are involved in the importing of components using css blocks.`);
           // throw new TemplateAnalysisError(`Stray reference to block import (${specifier.local.name}). Imports are removed during rewrite.`, {filename, ...ref.node.loc.start});
         }

--- a/packages/@css-blocks/jsx/src/utils/Errors.ts
+++ b/packages/@css-blocks/jsx/src/utils/Errors.ts
@@ -1,45 +1,9 @@
+import { CssBlockError } from "@css-blocks/core";
 
 export interface ErrorLocation {
   filename?: string;
   line?: number;
   column?: number;
-}
-
-interface HasPrefix {
-  prefix?: string;
-}
-/**
- * Custom CSS Blocks error base class. Will format `SourceLocation` into thrown
- * error message if provided.
- */
-export class CssBlockError extends Error {
-  static prefix = "Error";
-  origMessage: string;
-  private _location?: ErrorLocation | void;
-  constructor(message: string, location?: ErrorLocation | void) {
-    super(message);
-    this.origMessage = message;
-    this._location = location;
-    super.message = this.annotatedMessage();
-  }
-
-  private annotatedMessage() {
-    let loc = this.location;
-    if (!loc) {
-      return this.origMessage;
-    }
-    let filename = loc.filename || "";
-    let line = loc.line ? `${filename ? ":" : ""}${loc.line}` : "";
-    let column = loc.column ? `:${loc.column}` : "";
-    let locMessage = ` (${filename}${line}${column})`;
-    let c = <HasPrefix>this.constructor;
-    return `[css-blocks] ${c.prefix || CssBlockError.prefix}: ${this.origMessage}${locMessage}`;
-  }
-
-  get location(): ErrorLocation | void {
-    return this._location;
-  }
-
 }
 
 /**

--- a/packages/@css-blocks/jsx/test/analyzer/class-states-objstr-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/class-states-objstr-test.ts
@@ -235,7 +235,7 @@ export class Test {
     `).then((_analysis: Analyzer) => {
       assert.ok(false, "Should never get here");
     }).catch((err) => {
-      assert.equal(err.message, `[css-blocks] MalformedBlockPath: State "bar.pretty[state|color]" expects a value. (9:9)`);
+      assert.equal(err.message, `[css-blocks] MalformedBlockPath: State "bar.pretty[state|color]" expects a value. (<unknown file>:9:9)`);
     });
   }
 
@@ -294,7 +294,7 @@ export class Test {
     `).then((_analysis: Analyzer) => {
       assert.ok(false, "Should never get here");
     }).catch((err) => {
-      assert.equal(err.message, '[css-blocks] MalformedBlockPath: State ".pretty[state|awesome]" has no value "wat" on Block "bar".\n  Did you mean: .pretty[state|awesome]? (7:9)');
+      assert.equal(err.message, '[css-blocks] MalformedBlockPath: State ".pretty[state|awesome]" has no value "wat" on Block "bar".\n  Did you mean: .pretty[state|awesome]? (<unknown file>:7:9)');
     });
   }
 

--- a/packages/@css-blocks/jsx/test/analyzer/class-states-objstr-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/class-states-objstr-test.ts
@@ -149,7 +149,7 @@ export class Test {
     ).then((_analysis: Analyzer) => {
       assert.ok(false, "Should never get here");
     }).catch((err) => {
-      assert.equal(err.message, `[css-blocks] TemplateError: Can not apply multiple states at the same time from the exclusive state group ".pretty[state|color]". (:11:6)`);
+      assert.equal(err.message, `[css-blocks] TemplateError: Can not apply multiple states at the same time from the exclusive state group ".pretty[state|color]". (<unknown file>:11:6)`);
     });
   }
 

--- a/packages/@css-blocks/jsx/test/analyzer/dynamic-styles-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/dynamic-styles-test.ts
@@ -112,7 +112,7 @@ export class Test {
         assert.ok(false, "should not get here.");
       },
       (e) => {
-        assert.equal(e.message, "[css-blocks] AnalysisError: The spread operator is not allowed in CSS Block states. (9:18)");
+        assert.equal(e.message, "[css-blocks] AnalysisError: The spread operator is not allowed in CSS Block states. (<unknown file>:9:18)");
       });
   }
 }

--- a/packages/@css-blocks/jsx/test/analyzer/external-objstr-class-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/external-objstr-class-test.ts
@@ -98,7 +98,7 @@ export class Test {
       <div class={style}></div>;
     `,
     ).catch((err: Error) => {
-      assert.equal(err.message, '[css-blocks] AnalysisError: First argument passed to "objstr" call must be an object literal. (5:18)');
+      assert.equal(err.message, '[css-blocks] AnalysisError: First argument passed to "objstr" call must be an object literal. (<unknown file>:5:18)');
     });
   }
 
@@ -120,7 +120,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       (err) => {
-        assert.equal(err.message, '[css-blocks] AnalysisError: First argument passed to "objstr" call must be an object literal. (5:18)');
+        assert.equal(err.message, '[css-blocks] AnalysisError: First argument passed to "objstr" call must be an object literal. (<unknown file>:5:18)');
       });
   }
 
@@ -245,7 +245,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       (err) => {
-        assert.equal(err.message, `[css-blocks] AnalysisError: Undefined function for styling: objstr (4:18)`);
+        assert.equal(err.message, `[css-blocks] AnalysisError: Undefined function for styling: objstr (<unknown file>:4:18)`);
       });
   }
 
@@ -271,7 +271,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       (err) => {
-        assert.equal(err.message, `[css-blocks] AnalysisError: Cannot override the objstr import of 'obj-str' (5:6)`);
+        assert.equal(err.message, `[css-blocks] AnalysisError: Cannot override the objstr import of 'obj-str' (<unknown file>:5:6)`);
       });
   }
 
@@ -296,7 +296,7 @@ export class Test {
     ).then((_analysis: Analyzer) => {
       assert.ok(false, "should not have succeeded.");
     },     (err) => {
-      assert.equal(err.message, `[css-blocks] MalformedBlockPath: Nested expressions are not allowed in block expressions. (8:9)`);
+      assert.equal(err.message, `[css-blocks] MalformedBlockPath: Nested expressions are not allowed in block expressions. (<unknown file>:8:9)`);
     });
   }
 

--- a/packages/@css-blocks/jsx/test/analyzer/external-objstr-class-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/external-objstr-class-test.ts
@@ -145,7 +145,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       (err) => {
-        assert.equal(err.message, '[css-blocks] TemplateError: Classes "baz" and "foo" from the same block are not allowed on the same element at the same time. (:10:6)');
+        assert.equal(err.message, '[css-blocks] TemplateError: Classes "baz" and "foo" from the same block are not allowed on the same element at the same time. (<unknown file>:10:6)');
       });
   }
 

--- a/packages/@css-blocks/jsx/test/analyzer/external-objstr-root-styles-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/external-objstr-root-styles-test.ts
@@ -32,7 +32,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       e => {
-        assert.equal(e.message, "[css-blocks] AnalysisError: Cannot mix class names with block styles. (8:10)");
+        assert.equal(e.message, "[css-blocks] AnalysisError: Cannot mix class names with block styles. (<unknown file>:8:10)");
       });
   }
 
@@ -219,7 +219,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       e => {
-        assert.equal(e.message, "[css-blocks] AnalysisError: illegal use of a style variable. (9:8)");
+        assert.equal(e.message, "[css-blocks] AnalysisError: illegal use of a style variable. (<unknown file>:9:8)");
       });
   }
 
@@ -244,7 +244,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       e => {
-        assert.equal(e.message, "[css-blocks] AnalysisError: illegal assignment to a style variable. (9:8)");
+        assert.equal(e.message, "[css-blocks] AnalysisError: illegal assignment to a style variable. (<unknown file>:9:8)");
       });
   }
 

--- a/packages/@css-blocks/jsx/test/analyzer/inline-class-styles-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/inline-class-styles-test.ts
@@ -62,7 +62,7 @@ export class Test {
     ).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, '[css-blocks] MalformedBlockPath: No class named "baz" found on block "bar". Did you mean one of: :scope, .foo, .bar (4:47)');
+      assert.equal(err.message, '[css-blocks] MalformedBlockPath: No class named "baz" found on block "bar". Did you mean one of: :scope, .foo, .bar (<unknown file>:4:47)');
     });
   }
 
@@ -83,7 +83,7 @@ export class Test {
     ).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, '[css-blocks] MalformedBlockPath: State ".foo[state|baz]" has no value "biz" on Block "bar".\n  Did you mean: .foo[state|baz]? (4:47)');
+      assert.equal(err.message, '[css-blocks] MalformedBlockPath: State ".foo[state|baz]" has no value "biz" on Block "bar".\n  Did you mean: .foo[state|baz]? (<unknown file>:4:47)');
     });
   }
 }

--- a/packages/@css-blocks/jsx/test/analyzer/inline-objstr-styles-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/inline-objstr-styles-test.ts
@@ -72,7 +72,7 @@ export class Test {
       }
     `,
   ).catch((err: Error) => {
-      assert.equal(err.message, "[css-blocks] AnalysisError: The call to style function 'objstr' does not resolve to an import statement of a known style helper. (7:21)");
+      assert.equal(err.message, "[css-blocks] AnalysisError: The call to style function 'objstr' does not resolve to an import statement of a known style helper. (<unknown file>:7:21)");
     });
   }
 
@@ -91,7 +91,7 @@ export class Test {
       <div class={ wtf('nope') }></div>;
     `,
   ).catch((err: Error) => {
-      assert.equal(err.message, "[css-blocks] AnalysisError: Function called within class attribute value 'wtf' must be either an 'objstr' call, or a state reference (8:19)");
+      assert.equal(err.message, "[css-blocks] AnalysisError: Function called within class attribute value 'wtf' must be either an 'objstr' call, or a state reference (<unknown file>:8:19)");
     });
   }
 

--- a/packages/@css-blocks/jsx/test/analyzer/root-states-objstr-test.ts
+++ b/packages/@css-blocks/jsx/test/analyzer/root-states-objstr-test.ts
@@ -160,7 +160,7 @@ export class Test {
         assert.ok(false, "should not have succeeded.");
       },
       (err) => {
-        assert.equal(err.message, '[css-blocks] MalformedBlockPath: State ":scope[state|awesome]" has no value "wat" on Block "bar".\n  Did you mean: :scope[state|awesome]? (7:9)');
+        assert.equal(err.message, '[css-blocks] MalformedBlockPath: State ":scope[state|awesome]" has no value "wat" on Block "bar".\n  Did you mean: :scope[state|awesome]? (<unknown file>:7:9)');
       });
   }
 

--- a/packages/@css-blocks/jsx/test/blockImporter-test.ts
+++ b/packages/@css-blocks/jsx/test/blockImporter-test.ts
@@ -111,7 +111,7 @@ export class Test {
     `).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (4:8)`);
+      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (<unknown file>:4:8)`);
     });
   }
 
@@ -127,7 +127,7 @@ export class Test {
     `).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (4:8)`);
+      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (<unknown file>:4:8)`);
     });
   }
 
@@ -143,7 +143,7 @@ export class Test {
     `).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (4:8)`);
+      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (<unknown file>:4:8)`);
     });
   }
 
@@ -159,7 +159,7 @@ export class Test {
     `).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (3:6)`);
+      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (<unknown file>:3:6)`);
     });
   }
 
@@ -175,7 +175,7 @@ export class Test {
     `).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (4:8)`);
+      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (<unknown file>:4:8)`);
     });
   }
 
@@ -191,7 +191,7 @@ export class Test {
     `).then(() => {
       assert.equal("Should never get here", "");
     }).catch((err: Error) => {
-      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (4:8)`);
+      assert.equal(err.message, `[css-blocks] ImportError: Block identifier "biz" cannot be re-defined in any scope once imported. (<unknown file>:4:8)`);
     });
   }
 }


### PR DESCRIPTION
This PR will improve the CSS Blocks error reporting experience in the following ways:

- [x] Track text ranges instead of only the start position for errors. This will allow for better identification of the error in reporting interfaces like IDEs and command line reporters.
- [x] When compiling with the css-blocks cli, show the source lines and highlight the error region.
- [x] Selectors: Track source locations against the original source file when a source map is available.
- [x] Declarations: Track source locations against the original source file when a source map is available.
