### PR TITLE
Block import stack

### DIFF
--- a/packages/@css-blocks/cli/src/index.ts
+++ b/packages/@css-blocks/cli/src/index.ts
@@ -173,6 +173,15 @@ export class CLI {
     if (!errorHasRange(loc)) return;
     let filename = path.relative(process.cwd(), path.resolve(loc && loc.filename || blockFileRelative));
     this.println("\t" + this.chalk.bold.redBright(e.origMessage));
+    for (let referenceLocation of e.importStack.reverse()) {
+      if (referenceLocation.filename) {
+        referenceLocation.filename = path.relative(process.cwd(), path.resolve(referenceLocation.filename));
+      }
+      this.println(
+        this.chalk.bold.white("\tIn block referenced at"),
+        this.chalk.bold.whiteBright(charInFile(referenceLocation)),
+      );
+    }
     if (hasMappedPosition(loc)) {
       this.println(
         this.chalk.bold.white("\tAt compiled output of"),

--- a/packages/@css-blocks/cli/test/cli-test.ts
+++ b/packages/@css-blocks/cli/test/cli-test.ts
@@ -45,6 +45,7 @@ Found 1 error in 1 file.
     assert.equal(cli.output,
                  `error\t${relFixture("basic/transitive-error.block.css")}
 \tTwo distinct classes cannot be selected on the same element: .foo.bar
+\tIn block referenced at test/fixtures/basic/transitive-error.block.css:1:1
 \tAt ${relFixture("basic/error.block.css")}:1:5
 \t1: .foo.bar {
 \t2:   color: red;

--- a/packages/@css-blocks/cli/test/fixtures/basic/deep-transitive-error.block.css
+++ b/packages/@css-blocks/cli/test/fixtures/basic/deep-transitive-error.block.css
@@ -1,0 +1,5 @@
+@block error from "./transitive-error.block.css";
+
+:scope {
+  extends: error;
+}

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -73,7 +73,7 @@ export class BlockParser {
     let block = new Block(name, identifier, root);
 
     // Throw if we encounter any `!important` decls.
-    debug(` - Disallow Import`);
+    debug(` - Disallow Important`);
     await disallowImportant(configuration, root, sourceFile);
     // Discover and parse all block references included by this block.
     debug(` - Import Blocks`);

--- a/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/import-blocks.ts
@@ -44,10 +44,17 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
     // Import file, then parse file, then save block reference.
     let blockPromise: Promise<Block> = factory.getBlockRelative(block.identifier, blockPath);
 
-    // Validate our imported block name is a valid CSS identifier.
+    blockPromise = blockPromise.catch((e) => {
+      if (e instanceof errors.CssBlockError) {
+        e.importStack.push(sourceRange(factory.configuration, block.stylesheet, file, atRule));
+      }
+      throw e;
+    });
+
     let blockNames = parseBlockNames(blockList, true);
     for (let localName of Object.keys(blockNames)) {
       let remoteName = blockNames[localName];
+      // Validate our imported block name is a valid CSS identifier.
       if (!CLASS_NAME_IDENT.test(localName)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name in import. "${localName}" is not a legal CSS identifier.`,
@@ -104,5 +111,4 @@ export async function importBlocks(block: Block, factory: BlockFactory, file: st
     }
   });
   return block;
-
 }

--- a/packages/@css-blocks/core/src/SourceLocation.ts
+++ b/packages/@css-blocks/core/src/SourceLocation.ts
@@ -77,7 +77,7 @@ export function addSourcePositions(...locations: SourcePosition[]) {
  * @param node  The PostCSS Node object in question.
  * @returns An object representing the filename, line number and column number.
  */
-export function sourceRange(configuration: Configuration, root: postcss.Root | null | undefined, filename: string, node: postcss.Node): SourceRange | SourceFile {
+export function sourceRange(configuration: Configuration, root: postcss.Root | null | undefined, filename: string, node: postcss.Node): MappedSourceRange | SourceRange | SourceFile {
   if (node.source && node.source.start && node.source.end) {
     let {start, end} = node.source;
     return sourceOrSourceMappedRange(configuration, root, filename, start, end);

--- a/packages/@css-blocks/core/src/errors.ts
+++ b/packages/@css-blocks/core/src/errors.ts
@@ -26,11 +26,13 @@ interface HasPrefix {
 export class CssBlockError extends Error {
   static prefix = "Error";
   origMessage: string;
+  importStack: Array<SourceLocation.SourceRange | SourceLocation.MappedSourceRange | SourceLocation.SourceFile>;
   private _location?: ErrorLocation;
   constructor(message: string, location?: ErrorLocation) {
     super(message);
     this.origMessage = message;
     this._location = location;
+    this.importStack = new Array();
     super.message = this.annotatedMessage();
   }
 


### PR DESCRIPTION
When a block doesn't compile due to a downstream error in a block reference, the locations of the `@block` at-rules that brought in the failing block file are now part of the error's public interface and are displayed in the CLI error output.

The error locations are source-mapped where appropriate.

<img width="353" alt="import stack" src="https://user-images.githubusercontent.com/1839/64463090-9b068880-d0b7-11e9-8e55-2f75bbba6659.png">
