### PR TITLE
feat: Respect explicit exports for a block interface.

### DIFF
--- a/packages/@css-blocks/core/src/Analyzer/Analysis.ts
+++ b/packages/@css-blocks/core/src/Analyzer/Analysis.ts
@@ -21,6 +21,7 @@ import { ResolvedConfiguration } from "../configuration";
 import { Analyzer } from "./Analyzer";
 import { ElementAnalysis, SerializedElementAnalysis } from "./ElementAnalysis";
 import { TemplateValidator, TemplateValidatorOptions } from "./validations";
+import { DEFAULT_EXPORT } from "../BlockSyntax";
 
 /**
  * This interface defines a JSON friendly serialization
@@ -152,13 +153,13 @@ export class Analysis<K extends keyof TemplateTypes> {
     let names = Object.keys(this.blocks);
     for (let name of names) {
       if (this.blocks[name] === block) {
-        return name;
+        return name === DEFAULT_EXPORT ? "" : name;
       }
     }
     for (let name of names) {
       let superBlock = this.blocks[name].base;
       while (superBlock) {
-        if (superBlock === block) return name;
+        if (superBlock === block) return name === DEFAULT_EXPORT ? "" : name;
         superBlock = superBlock.base;
       }
     }

--- a/packages/@css-blocks/core/src/Analyzer/Analysis.ts
+++ b/packages/@css-blocks/core/src/Analyzer/Analysis.ts
@@ -15,13 +15,13 @@ import { ObjectDictionary, objectValues } from "@opticss/util";
 import { IdentGenerator } from "opticss";
 
 import { BlockFactory } from "../BlockParser";
+import { DEFAULT_EXPORT } from "../BlockSyntax";
 import { Block, Style } from "../BlockTree";
 import { ResolvedConfiguration } from "../configuration";
 
 import { Analyzer } from "./Analyzer";
 import { ElementAnalysis, SerializedElementAnalysis } from "./ElementAnalysis";
 import { TemplateValidator, TemplateValidatorOptions } from "./validations";
-import { DEFAULT_EXPORT } from "../BlockSyntax";
 
 /**
  * This interface defines a JSON friendly serialization

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -4,10 +4,10 @@ import { postcss } from "opticss";
 import { Analyzer } from "../Analyzer";
 import {
   BLOCK_DEBUG,
-  BLOCK_IMPORT,
   BLOCK_PROP_NAMES_RE,
   ROOT_CLASS,
   parseBlockDebug,
+  BLOCK_AT_RULES,
 } from "../BlockSyntax";
 import { Block } from "../BlockTree";
 import {
@@ -40,10 +40,11 @@ export class BlockCompiler {
     // Process all debug statements for this block.
     this.processDebugStatements(filename, root, block);
 
-    // Clean up CSS Block specific properties.
-    root.walkAtRules(BLOCK_IMPORT, (atRule) => {
-      atRule.remove();
-    });
+    // Clean up CSS Block specific at-rules.
+    for (let atRuleName of BLOCK_AT_RULES) {
+      root.walkAtRules(atRuleName, (atRule) => atRule.remove());
+    }
+
     root.walkRules(ROOT_CLASS, (rule) => {
       rule.walkDecls(BLOCK_PROP_NAMES_RE, (decl) => {
         decl.remove();
@@ -77,9 +78,6 @@ export class BlockCompiler {
       if (channel === "comment") {
         let text = `${ref.debug(this.config).join("\n * ")}\n`;
         atRule.replaceWith(this.postcss.comment({ text }));
-      } else {
-        // stderr/stdout are emitted during parse.
-        atRule.remove();
       }
     });
   }

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -3,11 +3,11 @@ import { postcss } from "opticss";
 
 import { Analyzer } from "../Analyzer";
 import {
+  BLOCK_AT_RULES,
   BLOCK_DEBUG,
   BLOCK_PROP_NAMES_RE,
   ROOT_CLASS,
   parseBlockDebug,
-  BLOCK_AT_RULES,
 } from "../BlockSyntax";
 import { Block } from "../BlockTree";
 import {

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -159,7 +159,7 @@ export class Block
    *   A single dot by itself returns the current block.
    * @returns The Style referenced at the supplied path.
    */
-  public externalLookup(path: string | BlockPath, errLoc?: SourceLocation): Styles | undefined {
+  public externalLookup(path: string | BlockPath, errLoc?: SourceRange | SourceFile): Styles | undefined {
     path = new BlockPath(path);
     let block = this.getExportedBlock(path.block);
     if (!block) {
@@ -180,8 +180,6 @@ export class Block
 
     return attr || klass || undefined;
   }
-
-
 
   /**
    * Add an absolute, normalized path as a compilation dependency. This is used

--- a/packages/@css-blocks/core/test/BlockSyntax/block-path-test.ts
+++ b/packages/@css-blocks/core/test/BlockSyntax/block-path-test.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { skip, suite, test } from "mocha-typescript";
 
-import { BlockPath, ERRORS } from "../../src/BlockSyntax";
+import { BlockPath, ERRORS, DEFAULT_EXPORT } from "../../src/BlockSyntax";
 import { ErrorLocation } from "../../src/errors";
 
 function parseBlockPath(blockPath: string, loc?: ErrorLocation): BlockPath {
@@ -18,7 +18,7 @@ export class BlockPathTests {
 
   @test "finds the class"() {
     let path = new BlockPath(".test");
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, ".test");
   }
 
@@ -42,37 +42,37 @@ export class BlockPathTests {
 
   @test "finds a namespaced attribute with value"() {
     let path = new BlockPath("[state|my-attr=value]");
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, `:scope[state|my-attr="value"]`);
   }
 
   @test "finds a namespace with value in single quotes"() {
     let path = new BlockPath("[state|my-attr='my value']");
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, `:scope[state|my-attr="my value"]`);
   }
 
   @test "finds a namespace with value in double quotes"() {
     let path = new BlockPath(`[state|my-attr="my value"]`);
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, `:scope[state|my-attr="my value"]`);
   }
 
   @test "finds a class with a namespace and value"() {
     let path = new BlockPath(".class[state|my-attr=value]");
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, `.class[state|my-attr="value"]`);
   }
 
   @test "finds a class with a namespace and value in single quotes"() {
     let path = new BlockPath(".class[state|my-attr='my value']");
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, `.class[state|my-attr="my value"]`);
   }
 
   @test "finds a class with a namespace and value in double quotes"() {
     let path = new BlockPath(`.class[state|my-attr="my value"]`);
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, `.class[state|my-attr="my value"]`);
   }
 
@@ -96,7 +96,7 @@ export class BlockPathTests {
 
   @test "finds :scope when passed empty string"() {
     let path = new BlockPath("");
-    assert.equal(path.block, "");
+    assert.equal(path.block, DEFAULT_EXPORT);
     assert.equal(path.path, ":scope");
     assert.equal(path.attribute, undefined);
   }

--- a/packages/@css-blocks/core/test/BlockSyntax/block-path-test.ts
+++ b/packages/@css-blocks/core/test/BlockSyntax/block-path-test.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { skip, suite, test } from "mocha-typescript";
 
-import { BlockPath, ERRORS, DEFAULT_EXPORT } from "../../src/BlockSyntax";
+import { BlockPath, DEFAULT_EXPORT, ERRORS  } from "../../src/BlockSyntax";
 import { ErrorLocation } from "../../src/errors";
 
 function parseBlockPath(blockPath: string, loc?: ErrorLocation): BlockPath {

--- a/packages/@css-blocks/core/test/block-interface-test.ts
+++ b/packages/@css-blocks/core/test/block-interface-test.ts
@@ -13,7 +13,7 @@ export class BlockInterfaceTests extends BEMProcessor {
       () => {
         assert(false, `Error ${errorType.name} was not raised.`);
       },
-      (reason) => {
+      (reason: Error) => {
         assert(reason instanceof errorType, reason.toString());
         assert.deepEqual(reason.message, message);
       });

--- a/packages/@css-blocks/core/test/validations/property-conflict-validator-test.ts
+++ b/packages/@css-blocks/core/test/validations/property-conflict-validator-test.ts
@@ -1313,7 +1313,7 @@ function constructElement(block: Block, ...styles: string[]) {
   let analysis = analyzer.newAnalysis(info);
 
   analysis.addBlock(":scope", block);
-  block.eachBlockReference((name, ref) => {
+  block.eachBlockExport((name, ref) => {
     analysis.addBlock(name, ref);
   });
 

--- a/packages/@css-blocks/glimmer/src/Analyzer.ts
+++ b/packages/@css-blocks/glimmer/src/Analyzer.ts
@@ -110,14 +110,11 @@ export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
     let block: Block | undefined = await this.resolveBlock(dir, componentName);
     if (!block) { return analysis; }
 
-    analysis.addBlock("", block);
     self.debug(`Analyzing ${componentName}. Got block for component.`);
 
     // Add all transitive block dependencies
     let localBlockNames: string[] = [];
-    analysis.addBlock("", block);
-    localBlockNames.push("<default>");
-    block.eachBlockReference((name, refBlock) => {
+    block.eachBlockExport((name, refBlock) => {
       analysis.addBlock(name, refBlock);
       localBlockNames.push(name);
     });

--- a/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
+++ b/packages/@css-blocks/glimmer/src/ElementAnalyzer.ts
@@ -27,6 +27,7 @@ export type AttrRewriteMap = { [key: string]: TemplateElement };
 const STATE = /^state:(?:([^.]+)\.)?([^.]+)$/;
 const STYLE_IF = "style-if";
 const STYLE_UNLESS = "style-unless";
+const DEFAULT_BLOCK_NAME = "default";
 
 const debug = debugGenerator("css-blocks:glimmer:element-analyzer");
 
@@ -40,7 +41,7 @@ export class ElementAnalyzer {
 
   constructor(analysis: GlimmerAnalysis, cssBlocksOpts: CSSBlocksConfiguration) {
     this.analysis = analysis;
-    this.block = analysis.getBlock("")!; // Local block check done elsewhere
+    this.block = analysis.getBlock(DEFAULT_BLOCK_NAME)!; // Local block check done elsewhere
     this.template = analysis.template;
     this.cssBlocksOpts = cssBlocksOpts;
   }
@@ -160,9 +161,9 @@ export class ElementAnalyzer {
   }
 
   private lookupClass(name: string, node: AST.Node): BlockClass {
-    let found = this.block.lookup(name);
+    let found = this.block.externalLookup(name);
     if (!found && !/\./.test(name)) {
-      found = this.block.lookup("." + name);
+      found = this.block.externalLookup("." + name);
     }
     if (found) {
       return <BlockClass>found;
@@ -257,7 +258,7 @@ export class ElementAnalyzer {
     element: TemplateElement,
     forRewrite: boolean,
   ): void {
-    let stateBlock = blockName ? this.block.getReferencedBlock(blockName) : this.block;
+    let stateBlock = blockName ? this.block.getExportedBlock(blockName) : this.block;
     if (stateBlock === null) {
       throw cssBlockError(`No block named ${blockName} referenced from ${this.debugBlockPath()}`, node, this.template);
     }

--- a/packages/@css-blocks/glimmer/src/Rewriter.ts
+++ b/packages/@css-blocks/glimmer/src/Rewriter.ts
@@ -19,6 +19,7 @@ import { ElementAnalyzer } from "./ElementAnalyzer";
 import { getEmberBuiltInStates, isEmberBuiltIn } from "./EmberBuiltins";
 import { CONCAT_HELPER_NAME } from "./helpers";
 import { ResolvedFile, TEMPLATE_TYPE } from "./Template";
+import { DEFAULT_EXPORT } from "@css-blocks/core/dist/src/BlockSyntax";
 
 // TODO: The state namespace should come from a config option.
 const STYLE_ATTR = /^(class$|state:)/;
@@ -66,7 +67,7 @@ export class GlimmerRewriter implements ASTPluginWithDeps {
     this.syntax        = syntax;
     this.analysis      = analysis;
     this.template      = analysis.template;
-    this.block         = analysis.getBlock("")!; // Local block check done elsewhere
+    this.block         = analysis.getBlock(DEFAULT_EXPORT)!; // Local block check done elsewhere
     this.styleMapping  = styleMapping;
     this.cssBlocksOpts = resolveConfiguration(cssBlocksOpts);
     this.elementCount  = 0;

--- a/packages/@css-blocks/glimmer/src/Rewriter.ts
+++ b/packages/@css-blocks/glimmer/src/Rewriter.ts
@@ -5,6 +5,7 @@ import {
   StyleMapping,
   resolveConfiguration,
 } from "@css-blocks/core";
+import { DEFAULT_EXPORT } from "@css-blocks/core/dist/src/BlockSyntax";
 import {
   AST,
   ASTPlugin,
@@ -19,7 +20,6 @@ import { ElementAnalyzer } from "./ElementAnalyzer";
 import { getEmberBuiltInStates, isEmberBuiltIn } from "./EmberBuiltins";
 import { CONCAT_HELPER_NAME } from "./helpers";
 import { ResolvedFile, TEMPLATE_TYPE } from "./Template";
-import { DEFAULT_EXPORT } from "@css-blocks/core/dist/src/BlockSyntax";
 
 // TODO: The state namespace should come from a config option.
 const STYLE_ATTR = /^(class$|state:)/;

--- a/packages/@css-blocks/glimmer/test/fixtures/readme-app/src/ui/components/page-layout/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/readme-app/src/ui/components/page-layout/stylesheet.css
@@ -5,3 +5,5 @@
 .sidebar[state|collapsed] { display: none; }
 .main { border-right: 2px groove gray; }
 .recommended { background-color: orange }
+
+@export grid;

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-dynamic-classes/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-dynamic-classes/stylesheet.css
@@ -12,3 +12,5 @@
 .world[state|thick] {
     border-width: 3px;
 }
+
+@export (h, t);

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-dynamic-states/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-dynamic-states/stylesheet.css
@@ -1,4 +1,4 @@
-@block h from "./header.css";
+@export h from "./header.css";
 
 :scope {
     color: red;
@@ -11,3 +11,4 @@
 .world[state|thick] {
     border-width: 3px;
 }
+

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-link-to/stylesheet.css
@@ -1,5 +1,5 @@
 @block external from "./external.css";
-@block util from "./util.css";
+@export util from "./util.css";
 
 :scope {
   extends: external;
@@ -33,3 +33,5 @@
 .link-4[state|disabled] {
   color: red;
 }
+
+@export external;

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-multiple-blocks/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-multiple-blocks/stylesheet.css
@@ -11,3 +11,5 @@
 .world[state|thick] {
     border-width: 3px;
 }
+
+@export h;

--- a/packages/@css-blocks/glimmer/test/stylesheet-analysis-test.ts
+++ b/packages/@css-blocks/glimmer/test/stylesheet-analysis-test.ts
@@ -16,7 +16,7 @@ describe("Stylesheet analysis", function() {
       let serializedAnalysis = analysis.serialize();
       assert.equal(analysis.template.identifier, "template:/styled-app/components/my-app");
       assert.deepEqual(serializedAnalysis.blocks, {
-        "": fixture("styled-app/src/ui/components/my-app/stylesheet.css"),
+        "default": fixture("styled-app/src/ui/components/my-app/stylesheet.css"),
       });
       assert.deepEqual(serializedAnalysis.stylesFound, [".editor", ".editor[state|disabled]" , ":scope", ":scope[state|is-loading]"]);
       let expected: ElementsAnalysis = {
@@ -45,7 +45,7 @@ describe("Stylesheet analysis", function() {
       let analysis = analyzer.getAnalysis(0).serialize();
       assert.equal(analysis.template.identifier, "template:/styled-app/components/with-multiple-blocks");
       assert.deepEqual(analysis.blocks, {
-        "": fixture("styled-app/src/ui/components/with-multiple-blocks/stylesheet.css"),
+        "default": fixture("styled-app/src/ui/components/with-multiple-blocks/stylesheet.css"),
         "h": fixture("styled-app/src/ui/components/with-multiple-blocks/header.css"),
       });
       assert.deepEqual(analysis.stylesFound, [".world", ".world[state|thick]", ":scope", "h.emphasis", "h.emphasis[state|extra]", "h:scope"]);
@@ -67,7 +67,7 @@ describe("Stylesheet analysis", function() {
       let analysis = analyzer.getAnalysis(0).serialize();
       assert.equal(analysis.template.identifier, "template:/styled-app/components/with-dynamic-states");
       assert.deepEqual(analysis.blocks, {
-        "": fixture("styled-app/src/ui/components/with-dynamic-states/stylesheet.css"),
+        "default": fixture("styled-app/src/ui/components/with-dynamic-states/stylesheet.css"),
         "h": fixture("styled-app/src/ui/components/with-dynamic-states/header.css"),
       });
       assert.deepEqual(analysis.stylesFound, [
@@ -119,7 +119,7 @@ describe("Stylesheet analysis", function() {
       let analysis = analyzer.getAnalysis(0).serialize();
       assert.equal(analysis.template.identifier, "template:/styled-app/components/with-dynamic-classes");
       assert.deepEqual(analysis.blocks, {
-        "": fixture("styled-app/src/ui/components/with-dynamic-classes/stylesheet.css"),
+        "default": fixture("styled-app/src/ui/components/with-dynamic-classes/stylesheet.css"),
         "h": fixture("styled-app/src/ui/components/with-dynamic-classes/header.css"),
         "t": fixture("styled-app/src/ui/components/with-dynamic-classes/typography.css"),
       });


### PR DESCRIPTION
Previously, the block's interface constituted of all of its imported blocks as well as the classes and states defined on the block.
Now, the block's public interface will consist of only that which is explicitly exported using @export