### PR TITLE
feat: Add document links provider.

### DIFF
--- a/packages/@css-blocks/language-server/src/Server.ts
+++ b/packages/@css-blocks/language-server/src/Server.ts
@@ -1,11 +1,12 @@
 import { BlockFactory, CssBlockError, Options, resolveConfiguration } from "@css-blocks/core/dist/src";
 import { BlockParser } from "@css-blocks/core/dist/src/BlockParser/BlockParser";
-import { CompletionItem, Definition, DidChangeConfigurationNotification, IConnection, InitializeParams, InitializeResult, TextDocumentChangeEvent, TextDocumentPositionParams, TextDocuments } from "vscode-languageserver";
+import { CompletionItem, Definition, DidChangeConfigurationNotification, DocumentLink, DocumentLinkParams, IConnection, InitializeParams, InitializeResult, TextDocumentChangeEvent, TextDocumentPositionParams, TextDocuments } from "vscode-languageserver";
 
 import { emberCompletionProvider } from "./completionProviders/emberCompletionProvider";
 import { createBlockFactory } from "./createBlockFactory";
 import { createBlockParser } from "./createBlockParser";
 import { emberDefinitionProvider } from "./definitionProviders/emberDefinitionProvider";
+import { blockLinksProvider } from "./documentLinksProviders/blockLinkProvider";
 import { documentContentChange } from "./eventHandlers/documentContentChange";
 import { PathTransformer } from "./pathTransformers/PathTransformer";
 import { SERVER_CAPABILITIES } from "./serverCapabilities";
@@ -80,6 +81,10 @@ export class Server {
 
     this.connection.onDefinition(async (params: TextDocumentPositionParams): Promise<Definition> => {
       return await emberDefinitionProvider(this.documents, this.blockFactory, params, this.pathTransformer);
+    });
+
+    this.connection.onDocumentLinks(async (params: DocumentLinkParams): Promise<DocumentLink[]> => {
+      return await blockLinksProvider(this.documents, params);
     });
   }
 

--- a/packages/@css-blocks/language-server/src/documentLinksProviders/blockLinkProvider.ts
+++ b/packages/@css-blocks/language-server/src/documentLinksProviders/blockLinkProvider.ts
@@ -1,0 +1,49 @@
+import * as path from "path";
+import { DocumentLinkParams, TextDocuments } from "vscode-languageserver";
+import { DocumentLink } from "vscode-languageserver-types";
+import { URI } from "vscode-uri";
+
+import { isBlockFile } from "../util/blockUtils";
+
+const LINK_REGEX = /from\s+(['"])([^'"]+)\1;/;
+
+export async function blockLinksProvider(documents: TextDocuments, params: DocumentLinkParams): Promise<DocumentLink[]> {
+  let { uri } = params.textDocument;
+
+  if (!isBlockFile(uri)) {
+    return [];
+  }
+
+  let document = documents.get(uri);
+
+  if (!document) {
+    return [];
+  }
+
+  let links: DocumentLink[] = [];
+  let lines = document.getText().split(/\r?\n/);
+  let blockDirPath = path.dirname(URI.parse(uri).fsPath);
+
+  lines.forEach((line, lineIndex) => {
+    let matches = line.match(LINK_REGEX);
+
+    if (!matches) {
+      return;
+    }
+
+    let relativeBlockReferencePath = matches[2];
+    let absoluteBlockReferencePath = path.resolve(blockDirPath, relativeBlockReferencePath);
+    let startColumn = line.indexOf(relativeBlockReferencePath);
+    let endColumn = startColumn + relativeBlockReferencePath.length;
+
+    links.push({
+      target: URI.file(absoluteBlockReferencePath).toString(),
+      range: {
+        start: { line: lineIndex, character: startColumn },
+        end: { line: lineIndex, character: endColumn },
+      },
+    });
+  });
+
+  return links;
+}

--- a/packages/@css-blocks/language-server/src/serverCapabilities.ts
+++ b/packages/@css-blocks/language-server/src/serverCapabilities.ts
@@ -5,6 +5,9 @@ export const SERVER_CAPABILITIES: ServerCapabilities = {
   definitionProvider: true,
   // TODO: implement support for this for showing documentation
   // hoverProvider: true,
+  documentLinkProvider: {
+    resolveProvider: true,
+  },
   documentSymbolProvider: false,
   completionProvider: {
     resolveProvider: true,

--- a/packages/@css-blocks/language-server/src/test/server-test.ts
+++ b/packages/@css-blocks/language-server/src/test/server-test.ts
@@ -2,7 +2,7 @@ import { Syntax } from "@css-blocks/core/dist/src";
 import { assert } from "chai";
 import { skip, suite, test } from "mocha-typescript";
 import * as path from "path";
-import { CompletionItemKind, CompletionRequest, DefinitionRequest, DiagnosticSeverity, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, IConnection, TextDocument, TextDocumentPositionParams, TextDocuments, createConnection } from "vscode-languageserver";
+import { CompletionItemKind, CompletionRequest, DefinitionRequest, DiagnosticSeverity, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, DocumentLinkParams, DocumentLinkRequest, IConnection, TextDocument, TextDocumentPositionParams, TextDocuments, createConnection } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 
 import { EmberClassicTransformer } from "../pathTransformers/EmberClassicTransformer";
@@ -350,5 +350,31 @@ export class LanguageServerServerTest {
       }],
     });
 
+  }
+
+  @test async "it returns the expected document links"() {
+    this.startServer();
+
+    let params: DocumentLinkParams = {
+      textDocument: {
+        uri: pathToUri("fixtures/ember-classic/styles/components/a.block.css"),
+      },
+    };
+
+    let response = await this.mockClientConnection.sendRequest(DocumentLinkRequest.type, params);
+
+    assert.deepEqual(response, [{
+      range: {
+        start: {
+          character: 19,
+          line: 0,
+        },
+        end: {
+          character: 44,
+          line: 0,
+        },
+      },
+      target: pathToUri("fixtures/ember-classic/styles/blocks/utils.block.css"),
+    }]);
   }
 }


### PR DESCRIPTION
For css and sass, vscode provides a "jump to file" feature for @import and
`url()` statements. For css-blocks, we only need to add this support for
custom "at rules" (@block, @export). For `url()`, the builtin vscode css
language server should still be providing that functionality.