### PR TITLE
feat: Basic preprocessor support.

### DIFF
--- a/packages/@css-blocks/language-server/package.json
+++ b/packages/@css-blocks/language-server/package.json
@@ -13,9 +13,11 @@
     "url": "https://github.com/LinkedIn/css-blocks"
   },
   "dependencies": {
-    "@css-blocks/core": "^0.24.0",
     "@css-blocks/config": "^0.24.0",
+    "@css-blocks/core": "^0.24.0",
     "@glimmer/syntax": "^0.42.1",
+    "glob": "^7.1.6",
+    "glob-escape": "^0.0.2",
     "opticss": "^0.6.2",
     "vscode-languageserver": "^5.2.1",
     "vscode-uri": "^2.0.3"

--- a/packages/@css-blocks/language-server/package.json
+++ b/packages/@css-blocks/language-server/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "mocha": "^6.1.4",
+    "node-sass": "^4.13.0",
     "tslint": "^5.9.1",
     "typescript": "~3.6",
     "watch": "^1.0.2"

--- a/packages/@css-blocks/language-server/src/completionProviders/emberCompletionProvider.ts
+++ b/packages/@css-blocks/language-server/src/completionProviders/emberCompletionProvider.ts
@@ -1,4 +1,4 @@
-import { BlockFactory } from "@css-blocks/core/dist/src";
+import { BlockFactory } from "@css-blocks/core";
 import { CompletionItem, TextDocumentPositionParams, TextDocuments } from "vscode-languageserver";
 
 import { PathTransformer } from "../pathTransformers/PathTransformer";
@@ -15,7 +15,7 @@ export async function emberCompletionProvider(documents: TextDocuments, factory:
 
   if (isTemplateFile(document.uri)) {
     return await getHbsCompletions(document, params.position, factory, pathTransformer);
-  } else if (isBlockFile(document.uri)) {
+  } else if (isBlockFile(document.uri, factory.configuration)) {
     return await getBlockCompletions(document, params.position);
   } else {
     return [];

--- a/packages/@css-blocks/language-server/src/createBlockFactory.ts
+++ b/packages/@css-blocks/language-server/src/createBlockFactory.ts
@@ -1,4 +1,4 @@
-import { BlockFactory, Options } from "@css-blocks/core/dist/src";
+import { BlockFactory, Options } from "@css-blocks/core";
 import { postcss } from "opticss";
 
 export function createBlockFactory(config: Options) {

--- a/packages/@css-blocks/language-server/src/definitionProviders/emberDefinitionProvider.ts
+++ b/packages/@css-blocks/language-server/src/definitionProviders/emberDefinitionProvider.ts
@@ -1,4 +1,4 @@
-import { BlockFactory } from "@css-blocks/core/dist/src";
+import { BlockFactory } from "@css-blocks/core";
 import { Definition, TextDocumentPositionParams, TextDocuments } from "vscode-languageserver";
 
 import { PathTransformer } from "../pathTransformers/PathTransformer";

--- a/packages/@css-blocks/language-server/src/documentLinksProviders/blockLinkProvider.ts
+++ b/packages/@css-blocks/language-server/src/documentLinksProviders/blockLinkProvider.ts
@@ -1,3 +1,4 @@
+import { Configuration } from "@css-blocks/core";
 import * as path from "path";
 import { DocumentLinkParams, TextDocuments } from "vscode-languageserver";
 import { DocumentLink } from "vscode-languageserver-types";
@@ -7,10 +8,10 @@ import { isBlockFile } from "../util/blockUtils";
 
 const LINK_REGEX = /from\s+(['"])([^'"]+)\1;/;
 
-export async function blockLinksProvider(documents: TextDocuments, params: DocumentLinkParams): Promise<DocumentLink[]> {
+export async function blockLinksProvider(documents: TextDocuments, params: DocumentLinkParams, config: Readonly<Configuration>): Promise<DocumentLink[]> {
   let { uri } = params.textDocument;
 
-  if (!isBlockFile(uri)) {
+  if (!isBlockFile(uri, config)) {
     return [];
   }
 

--- a/packages/@css-blocks/language-server/src/eventHandlers/documentContentChange.ts
+++ b/packages/@css-blocks/language-server/src/eventHandlers/documentContentChange.ts
@@ -1,4 +1,4 @@
-import { BlockFactory, CssBlockError } from "@css-blocks/core/dist/src";
+import { BlockFactory, CssBlockError } from "@css-blocks/core";
 import { TextDocumentChangeEvent } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 
@@ -7,7 +7,7 @@ import { isBlockFile } from "../util/blockUtils";
 export async function documentContentChange(e: TextDocumentChangeEvent, blockFactory: BlockFactory): Promise<CssBlockError[]> {
   const { uri } = e.document;
 
-  if (isBlockFile(uri)) {
+  if (isBlockFile(uri, blockFactory.configuration)) {
     try {
       // parses the block file to get the block and errors if there's a problem
       // along the way. The importer ensures that we're getting live contents if

--- a/packages/@css-blocks/language-server/src/pathTransformers/EmberClassicTransformer.ts
+++ b/packages/@css-blocks/language-server/src/pathTransformers/EmberClassicTransformer.ts
@@ -1,32 +1,60 @@
-import { Syntax } from "@css-blocks/core/dist/src";
+import { Syntax } from "@css-blocks/core";
+import { existsSync } from "fs";
+import * as glob from "glob";
+import * as globEscape from "glob-escape";
 import * as path from "path";
 
 import { PathTransformer } from "./PathTransformer";
 
+const TEMPLATES_DIR_RE = new RegExp(`${path.sep}templates${path.sep}`);
+const STYLES_DIR_RE = new RegExp(`${path.sep}styles${path.sep}`);
+
 export class EmberClassicTransformer implements PathTransformer {
-  _syntax: Syntax;
+  _syntaxes: Array<Syntax>;
   _templateExtension = "hbs";
+  _allowsAnySyntax: boolean;
 
-  // TODO: Accept an array of syntaxes that are set up in the preprocessor configuration.
-  constructor(syntax: Syntax) {
-    this._syntax = syntax;
+  constructor(syntaxes: Array<Syntax>) {
+    this._syntaxes = syntaxes.filter(s => s !== Syntax.other);
+    this._allowsAnySyntax = syntaxes.includes(Syntax.other);
   }
 
-  templateToBlock(templatePath: string): string {
-    return templatePath
-      .replace(/.hbs$/, `.block.${this._syntax}`)
-      .replace(
-        new RegExp(`${path.sep}templates${path.sep}`),
-        `${path.sep}styles${path.sep}`,
-      );
+  _blockSyntaxSupported(extension: string): boolean {
+    if (this._allowsAnySyntax || extension === "css") {
+      return true;
+    } else {
+      return !!this._syntaxes.find(s => s === extension);
+    }
   }
 
-  blockToTemplate(blockPath: string): string {
-    return blockPath
-      .replace(new RegExp(`\.block\.${this._syntax}$`), `.${this._templateExtension}`)
-      .replace(
-        new RegExp(`${path.sep}styles${path.sep}`),
-        `${path.sep}templates${path.sep}`,
-      );
+  templateToBlock(templatePath: string): string | null {
+    let pathObj = path.parse(templatePath.replace(TEMPLATES_DIR_RE, `${path.sep}styles${path.sep}`));
+    let dir = pathObj.dir;
+    let filename = pathObj.name;
+    let pattern = `${globEscape(filename)}.block.*`;
+    let files = glob.sync(pattern, {cwd: dir});
+    for (let file of files) {
+      let ext = path.extname(file).substring(1);
+      if (this._blockSyntaxSupported(ext)) {
+        return path.join(dir, file);
+      }
+    }
+    return null;
+  }
+
+  blockToTemplate(blockPath: string): string | null {
+    let pathObj = path.parse(blockPath);
+    delete pathObj.base;
+    pathObj.ext = `.${this._templateExtension}`;
+    if (pathObj.name.endsWith(".block")) {
+      pathObj.name = pathObj.name.substring(0, pathObj.name.length - 6);
+    }
+    pathObj.dir = pathObj.dir.replace(STYLES_DIR_RE, `${path.sep}templates${path.sep}`);
+    let templatePath = path.format(pathObj);
+    if (existsSync(templatePath)) {
+      return templatePath;
+    } else {
+      return null;
+    }
   }
 }

--- a/packages/@css-blocks/language-server/src/pathTransformers/PathTransformer.ts
+++ b/packages/@css-blocks/language-server/src/pathTransformers/PathTransformer.ts
@@ -1,7 +1,4 @@
-import { Syntax } from "@css-blocks/core/dist/src";
-
 export interface PathTransformer {
-  _syntax: Syntax;
-  templateToBlock(templatePath: string): string;
-  blockToTemplate(blockPath: string): string;
+  templateToBlock(templatePath: string): string | null;
+  blockToTemplate(blockPath: string): string | null;
 }

--- a/packages/@css-blocks/language-server/src/run.ts
+++ b/packages/@css-blocks/language-server/src/run.ts
@@ -1,16 +1,10 @@
-import { Syntax } from "@css-blocks/core";
 import { ProposedFeatures, TextDocuments, createConnection } from "vscode-languageserver";
 
-import { EmberClassicTransformer } from "./pathTransformers/EmberClassicTransformer";
 import { Server } from "./Server";
 
-// TODO: We will eventually need to support different path transformations
-// and block syntax depending on configuration. For now we are just assuming
-// an ember classic project and css syntax.
-const pathTransformer = new EmberClassicTransformer(Syntax.css);
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments();
 
-let server = new Server(connection, documents, pathTransformer);
+let server = new Server(connection, documents);
 
 server.listen();

--- a/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/css-blocks.config.js
+++ b/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/css-blocks.config.js
@@ -1,0 +1,32 @@
+const sass = require("node-sass");
+
+module.exports = {
+  preprocessors: {
+    scss(fullPath, content, _configuration, _sourceMap) {
+      return new Promise((resolve, reject) => {
+        sass.render(
+          {
+            file: fullPath,
+            outFile: fullPath.replace(/\.scss$/, ".css"),
+            data: content,
+            sourceMap: true,
+            outputStyle: "expanded",
+            indentedSyntax: false,
+          },
+          (err, result) => {
+            if (err) {
+              reject(err);
+            } else {
+              let resolvedFile = {
+                content: result.css.toString(),
+                sourceMap: result.map.toString(),
+                dependencies: result.stats.includedFiles,
+              };
+              resolve(resolvedFile);
+            }
+          },
+        );
+      });
+    }
+  }
+};

--- a/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/blocks/block-with-errors.block.scss
+++ b/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/blocks/block-with-errors.block.scss
@@ -1,0 +1,7 @@
+.a {
+  text-decoration: none;
+}
+
+.a.b {
+  display: inline;
+}

--- a/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/blocks/utils.block.scss
+++ b/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/blocks/utils.block.scss
@@ -1,0 +1,8 @@
+.display-flex {
+  display: flex;
+}
+
+.display-block {
+  display: block;
+}
+

--- a/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/components/a.block.scss
+++ b/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/components/a.block.scss
@@ -1,0 +1,19 @@
+@block utils from "../blocks/utils.block.scss";
+
+.a-1 {
+  vertical-align: top;
+}
+
+.a-2 {
+  vertical-align: middle;
+}
+
+.a-3 {
+  color: red;
+}
+
+.a-3[whuut] {
+  vertical-align: bottom;
+}
+
+@export utils;

--- a/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/components/import-completions.block.scss
+++ b/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/styles/components/import-completions.block.scss
@@ -1,0 +1,4 @@
+@block randoBlock from "../";
+@export utils from "../blocks/";
+@block aBlock from "../blocks/ut";
+@export bBlock from "./";

--- a/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/templates/components/a.hbs
+++ b/packages/@css-blocks/language-server/src/test/fixtures/ember-classic-scss/templates/components/a.hbs
@@ -1,0 +1,7 @@
+<p block:class="a-2">lorem</p>
+<span utils:class="display-block"></span>
+<div block:class="
+  a-3
+"></div>
+<div block:class=i-do-not-exist-1></div>
+<MyComponent block:class="i-do-not-exist-2"/>

--- a/packages/@css-blocks/language-server/src/test/server-test-scss.ts
+++ b/packages/@css-blocks/language-server/src/test/server-test-scss.ts
@@ -1,0 +1,481 @@
+import { assert } from "chai";
+import { skip, suite, test } from "mocha-typescript";
+import * as path from "path";
+import { CompletionItemKind, CompletionRequest, DefinitionRequest, DiagnosticSeverity, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification, DidSaveTextDocumentParams, DocumentLinkParams, DocumentLinkRequest, IConnection, InitializeParams, InitializeRequest, TextDocument, TextDocumentPositionParams, TextDocuments, createConnection } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+
+import { Server } from "../Server";
+import { transformPathsFromUri } from "../util/pathTransformer";
+
+import { createTextDocumentMock } from "./util/createTextDocumentMock";
+import { createTextDocumentsMock } from "./util/createTextDocumentsMock";
+import { TestStream } from "./util/TestStream";
+
+const TEST_DIR = path.resolve(__dirname, "..", "..", "src", "test");
+const pathToUri = (relativePath: string) => URI.file(path.resolve(TEST_DIR, relativePath)).toString();
+
+const EMBER_CLASSIC_PROJECT = path.resolve(TEST_DIR, "fixtures", "ember-classic-scss");
+const EMBER_CLASSIC_TEMPLATE_A_URI = pathToUri("fixtures/ember-classic-scss/templates/components/a.hbs");
+const EMBER_CLASSIC_BLOCK_A_URI = pathToUri("fixtures/ember-classic-scss/styles/components/a.block.scss");
+
+@suite("Language Server | Server With Sass Support | tags: ember-classic, language-server, sass")
+export class LanguageServerServerTest {
+  mockServerConnection: IConnection;
+  mockClientConnection: IConnection;
+  documents: TextDocuments;
+  cwd: string | undefined;
+
+  constructor() {
+    const input = new TestStream();
+    const output = new TestStream();
+
+    this.mockServerConnection = createConnection(input, output);
+    this.mockClientConnection = createConnection(output, input);
+    this.mockClientConnection.listen();
+
+    const textDocumentsByUri = new Map<string, TextDocument>();
+    textDocumentsByUri.set(EMBER_CLASSIC_TEMPLATE_A_URI, createTextDocumentMock(EMBER_CLASSIC_TEMPLATE_A_URI));
+    textDocumentsByUri.set(EMBER_CLASSIC_BLOCK_A_URI, createTextDocumentMock(EMBER_CLASSIC_BLOCK_A_URI));
+
+    this.documents = createTextDocumentsMock(textDocumentsByUri);
+  }
+
+  private async startServer(rootPath = EMBER_CLASSIC_PROJECT) {
+    const server = new Server(this.mockServerConnection, this.documents);
+
+    server.listen();
+
+    let params: InitializeParams = {
+      processId: null,
+      rootPath,
+      rootUri: URI.file(rootPath).toString(),
+      capabilities: {},
+      workspaceFolders: [{
+        name: path.basename(rootPath),
+        uri: URI.file(rootPath).toString(),
+      }],
+    };
+    await this.mockClientConnection.sendRequest(InitializeRequest.type, params);
+
+    return server;
+  }
+
+  before() {
+    this.cwd = process.cwd();
+    process.chdir(EMBER_CLASSIC_PROJECT);
+  }
+
+  after() {
+    process.chdir(this.cwd!);
+  }
+
+  @test async "it returns the expected definitions for local block"() {
+    let server = await this.startServer();
+
+    const params: TextDocumentPositionParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      },
+      position: {
+        line: 0,
+        character: 17,
+      },
+    };
+
+    const response = await this.mockClientConnection.sendRequest(DefinitionRequest.type, params);
+
+    assert.deepEqual(response, {
+      uri: transformPathsFromUri(EMBER_CLASSIC_TEMPLATE_A_URI, server.pathTransformer, server.config).blockUri || "",
+      range: {
+        start: { line: 6, character: 1 },
+        end: { line: 6, character: 1 },
+      },
+    });
+  }
+
+  @test async "it returns the expected definitions for a class that is defined as part of a multiline string"() {
+    let server = await this.startServer();
+
+    const params: TextDocumentPositionParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      },
+      position: {
+        line: 3,
+        character: 5,
+      },
+    };
+
+    const response = await this.mockClientConnection.sendRequest(DefinitionRequest.type, params);
+
+    assert.deepEqual(response, {
+      uri: transformPathsFromUri(EMBER_CLASSIC_TEMPLATE_A_URI, server.pathTransformer, server.config).blockUri || "",
+      range: {
+        start: { line: 10, character: 1 },
+        end: { line: 10, character: 1 },
+      },
+    });
+  }
+
+  @test async "it returns the expected definitions for a block reference"() {
+    await this.startServer();
+
+    const params: TextDocumentPositionParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      },
+      position: {
+        line: 1,
+        character: 19,
+      },
+    };
+
+    const response = await this.mockClientConnection.sendRequest(DefinitionRequest.type, params);
+
+    assert.deepEqual(response, {
+      uri: pathToUri("fixtures/ember-classic-scss/styles/blocks/utils.block.scss"),
+      range: {
+        start: { line: 4, character: 1 },
+        end: { line: 4, character: 1 },
+      },
+    });
+  }
+
+  @test async "it returns no definitions when triggering go to definition on a class that has not been defined"() {
+    await this.startServer();
+
+    const params: TextDocumentPositionParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      },
+      position: {
+        line: 5,
+        character: 17,
+      },
+    };
+
+    const response = await this.mockClientConnection.sendRequest(DefinitionRequest.type, params);
+
+    assert.deepEqual(response, []);
+  }
+
+  @test async "it returns the expected completions for local block"() {
+    await this.startServer();
+
+    const params: TextDocumentPositionParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      },
+      position: {
+        line: 0,
+        character: 17,
+      },
+    };
+
+    const response = await this.mockClientConnection.sendRequest(CompletionRequest.type, params);
+    const expectedCompletionKind = CompletionItemKind.Property;
+
+    assert.deepEqual(response, [{ label: "a-1", kind: expectedCompletionKind },
+                                { label: "a-2", kind: expectedCompletionKind },
+                                { label: "a-3", kind: expectedCompletionKind }]);
+  }
+
+  @test async "it returns the expected completions for a block reference"() {
+    await this.startServer();
+
+    const params: TextDocumentPositionParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      },
+      position: {
+        line: 1,
+        character: 20,
+      },
+    };
+
+    const response = await this.mockClientConnection.sendRequest(CompletionRequest.type, params);
+    const expectedCompletionKind = CompletionItemKind.Property;
+
+    assert.deepEqual(response, [{ label: "display-flex", kind: expectedCompletionKind },
+                                { label: "display-block", kind: expectedCompletionKind },
+    ]);
+  }
+
+  @test async "it returns the expected template diagnostics for a class that is not defined when a file is opened"() {
+    await this.startServer();
+
+    const document = this.documents.get(EMBER_CLASSIC_TEMPLATE_A_URI)!;
+
+    const params: DidOpenTextDocumentParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+        version: 1,
+        text: document.getText(),
+        languageId: "handlebars",
+      },
+    };
+
+    this.mockClientConnection.sendNotification(DidOpenTextDocumentNotification.type, params);
+
+    let publishParams = await new Promise((resolve) => {
+      this.mockClientConnection.onNotification((method, params) => {
+        if (method === "textDocument/publishDiagnostics") {
+          if (params.diagnostics.length) {
+            resolve(params);
+          }
+        }
+      });
+    });
+
+    assert.deepEqual(publishParams, {
+      uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      diagnostics: [{
+        severity: DiagnosticSeverity.Error,
+        range: {
+          start: {
+            line: 5,
+            character: 17,
+          },
+          end: {
+            line: 5,
+            character: 33,
+          },
+        },
+        message: "Class name 'i-do-not-exist-1' not found.",
+      },            {
+        severity: DiagnosticSeverity.Error,
+        range: {
+          start: {
+            line: 6,
+            character: 26,
+          },
+          end: {
+            line: 6,
+            character: 42,
+          },
+        },
+        message: "Class name 'i-do-not-exist-2' not found.",
+      }],
+    });
+  }
+
+  // TODO: figure out why the client does not receive the notification after
+  // sending synthetic save event. This is pretty much covered by the properly
+  // functioning "onDidOpen" test, and the "ondDidSave" event is reliably fired
+  // under real working conditions.
+  @skip async "it returns the expected template diagnostics when using a class that is not defined when a file is saved"() {
+    await this.startServer();
+
+    const document = this.documents.get(EMBER_CLASSIC_TEMPLATE_A_URI)!;
+
+    const params: DidSaveTextDocumentParams = {
+      textDocument: {
+        uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+        version: 2,
+      },
+      text: document.getText(),
+    };
+
+    this.mockClientConnection.sendNotification(DidSaveTextDocumentNotification.type, params);
+
+    let publishParams = await new Promise((resolve) => {
+      this.mockClientConnection.onNotification((method, params) => {
+        if (method === "textDocument/publishDiagnostics") {
+          if (params.diagnostics.length) {
+            resolve(params);
+          }
+        }
+      });
+    });
+
+    assert.deepEqual(publishParams, {
+      uri: EMBER_CLASSIC_TEMPLATE_A_URI,
+      diagnostics: [{
+        severity: DiagnosticSeverity.Error,
+        range: {
+          start: {
+            line: 0,
+            character: 14,
+          },
+          end: {
+            line: 0,
+            character: 32,
+          },
+        },
+        message: 'No Style ".non-existent-class" found on Block "a".',
+      }],
+    });
+  }
+
+  @test async "it returns the expected css block diagnostics when a block file is changed"() {
+    const server = await this.startServer();
+    const blockWithErrorsUri = pathToUri("fixtures/ember-classic/styles/blocks/block-with-errors.block.css");
+    await server.onDidChangeContent({
+      document: createTextDocumentMock(blockWithErrorsUri),
+    });
+
+    let publishParams = await new Promise((resolve) => {
+      this.mockClientConnection.onNotification((method, params) => {
+        if (method === "textDocument/publishDiagnostics") {
+          if (params.diagnostics.length) {
+            resolve(params);
+          }
+        }
+      });
+    });
+
+    assert.deepEqual(publishParams, {
+      uri: blockWithErrorsUri,
+      diagnostics: [{
+        severity: DiagnosticSeverity.Error,
+        range: {
+          start: {
+            line: 4,
+            character: 2,
+          },
+          end: {
+            line: 4,
+            character: 4,
+          },
+        },
+        message: "Two distinct classes cannot be selected on the same element: .a.b",
+      }],
+    });
+
+  }
+
+  @test async "it returns the expected document links"() {
+    await this.startServer();
+
+    let params: DocumentLinkParams = {
+      textDocument: {
+        uri: pathToUri("fixtures/ember-classic-scss/styles/components/a.block.scss"),
+      },
+    };
+
+    let response = await this.mockClientConnection.sendRequest(DocumentLinkRequest.type, params);
+
+    assert.deepEqual(response, [{
+      range: {
+        start: {
+          character: 19,
+          line: 0,
+        },
+        end: {
+          character: 45,
+          line: 0,
+        },
+      },
+      target: pathToUri("fixtures/ember-classic-scss/styles/blocks/utils.block.scss"),
+    }]);
+  }
+
+  @test async "it returns the expected completions for a block/export path in a block file"() {
+    const textDocumentsByUri = new Map<string, TextDocument>();
+    const importCompletionsFixtureUri = pathToUri("fixtures/ember-classic/styles/components/import-completions.block.css");
+    textDocumentsByUri.set(importCompletionsFixtureUri, createTextDocumentMock(importCompletionsFixtureUri));
+    this.documents = createTextDocumentsMock(textDocumentsByUri);
+
+    await this.startServer();
+
+    // directory completions
+    const params1: TextDocumentPositionParams = {
+      textDocument: {
+        uri: importCompletionsFixtureUri,
+      },
+      position: {
+        line: 0,
+        character: 27,
+      },
+    };
+
+    const response1 = await this.mockClientConnection.sendRequest(CompletionRequest.type, params1);
+
+    assert.deepEqual(
+      response1, [
+      {
+        kind: 19,
+        label: "blocks",
+      },
+      {
+        kind: 19,
+        label: "components",
+      },
+    ],
+      "it returns the expected folder completions");
+
+    // file name completions
+    const params2: TextDocumentPositionParams = {
+      textDocument: {
+        uri: importCompletionsFixtureUri,
+      },
+      position: {
+        line: 1,
+        character: 30,
+      },
+    };
+
+    const response2 = await this.mockClientConnection.sendRequest(CompletionRequest.type, params2);
+
+    assert.deepEqual(
+      response2, [
+      {
+        "kind": 17,
+        "label": "block-with-errors.block.css",
+      },
+      {
+        "kind": 17,
+        "label": "utils.block.css",
+      },
+    ],
+      "it returns the expected file completions");
+
+    // partially typed filename completion
+    const params3: TextDocumentPositionParams = {
+      textDocument: {
+        uri: importCompletionsFixtureUri,
+      },
+      position: {
+        line: 2,
+        character: 32,
+      },
+    };
+
+    const response3 = await this.mockClientConnection.sendRequest(CompletionRequest.type, params3);
+
+    assert.deepEqual(
+      response3, [
+      {
+        kind: 17,
+        label: "block-with-errors.block.css",
+      },
+      {
+        kind: 17,
+        label: "utils.block.css",
+      },
+    ],
+      "it returns the expected file completions");
+
+    // local directory reference
+    const params4: TextDocumentPositionParams = {
+      textDocument: {
+        uri: importCompletionsFixtureUri,
+      },
+      position: {
+        line: 3,
+        character: 23,
+      },
+    };
+
+    const response4 = await this.mockClientConnection.sendRequest(CompletionRequest.type, params4);
+
+    assert.deepEqual(
+      response4, [
+      {
+        kind: 17,
+        label: "a.block.css",
+      },
+    ],
+      "it returns the expected file completions");
+  }
+}

--- a/packages/@css-blocks/language-server/src/types/glob-escape.d.ts
+++ b/packages/@css-blocks/language-server/src/types/glob-escape.d.ts
@@ -1,0 +1,4 @@
+declare module 'glob-escape' {
+  const globEscape: (string) => string;
+  export = globEscape;
+}

--- a/packages/@css-blocks/language-server/src/util/diagnosticsUtils.ts
+++ b/packages/@css-blocks/language-server/src/util/diagnosticsUtils.ts
@@ -1,4 +1,4 @@
-import { CssBlockError, errorHasRange } from "@css-blocks/core/dist/src";
+import { CssBlockError, errorHasRange } from "@css-blocks/core";
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
 
 export function convertErrorsToDiagnostics(errors: CssBlockError[]): Diagnostic[] {

--- a/packages/@css-blocks/language-server/src/util/hbsCompletionProvider.ts
+++ b/packages/@css-blocks/language-server/src/util/hbsCompletionProvider.ts
@@ -7,7 +7,7 @@ import { AttributeType, ClassAttribute, getItemAtCursor } from "./hbsUtils";
 import { transformPathsFromUri } from "./pathTransformer";
 
 export async function getHbsCompletions(document: TextDocument, position: Position, blockFactory: BlockFactory, pathTransformer: PathTransformer): Promise<CompletionItem[]> {
-  let transformedPaths = transformPathsFromUri(document.uri, pathTransformer);
+  let transformedPaths = transformPathsFromUri(document.uri, pathTransformer, blockFactory.configuration);
   let { blockFsPath } = transformedPaths;
 
   if (!blockFsPath) {

--- a/packages/@css-blocks/language-server/src/util/hbsDefinitionProvider.ts
+++ b/packages/@css-blocks/language-server/src/util/hbsDefinitionProvider.ts
@@ -9,7 +9,7 @@ import { AttributeType, getItemAtCursor } from "./hbsUtils";
 import { transformPathsFromUri } from "./pathTransformer";
 
 export async function getHbsDefinition(document: TextDocument, position: Position, blockFactory: BlockFactory, pathTransformer: PathTransformer): Promise<Definition> {
-  let transformedPaths = transformPathsFromUri(document.uri, pathTransformer);
+  let transformedPaths = transformPathsFromUri(document.uri, pathTransformer, blockFactory.configuration);
   let { blockFsPath } = transformedPaths;
 
   if (!blockFsPath) {

--- a/packages/@css-blocks/language-server/src/util/hbsUtils.ts
+++ b/packages/@css-blocks/language-server/src/util/hbsUtils.ts
@@ -141,6 +141,7 @@ export async function validateTemplates(
         const { blockFsPath, templateUri } = transformPathsFromUri(
           document.uri,
           pathTransformer,
+          factory.configuration,
         );
         if (blockFsPath && templateUri) {
           try {

--- a/packages/@css-blocks/language-server/src/util/pathTransformer.ts
+++ b/packages/@css-blocks/language-server/src/util/pathTransformer.ts
@@ -1,3 +1,4 @@
+import { Configuration } from "@css-blocks/core";
 import { URI } from "vscode-uri";
 
 import { PathTransformer } from "../pathTransformers/PathTransformer";
@@ -6,17 +7,17 @@ import { isBlockFile } from "./blockUtils";
 import { isTemplateFile } from "./hbsUtils";
 
 interface TransformedPaths {
-  templateFsPath?: string;
-  templateUri?: string;
-  blockFsPath?: string;
-  blockUri?: string;
+  templateFsPath?: string | null;
+  templateUri?: string | null;
+  blockFsPath?: string | null;
+  blockUri?: string | null;
 }
 
 /**
  * Given a uri, return a map of corresponding block and template file system
  * and uri paths.
  */
-export function transformPathsFromUri(uri: string, transformer: PathTransformer): TransformedPaths {
+export function transformPathsFromUri(uri: string, transformer: PathTransformer, config: Readonly<Configuration>): TransformedPaths {
   let fsPath;
 
   try {
@@ -26,20 +27,22 @@ export function transformPathsFromUri(uri: string, transformer: PathTransformer)
   }
 
   if (isTemplateFile(uri)) {
+    let blockFsPath = transformer.templateToBlock(fsPath);
     return {
-      blockFsPath: transformer.templateToBlock(fsPath),
-      blockUri: URI.file(transformer.templateToBlock(fsPath)).toString(),
+      blockFsPath,
+      blockUri: blockFsPath && URI.file(blockFsPath).toString(),
       templateFsPath: fsPath,
       templateUri: uri,
     };
   }
 
-  if (isBlockFile(uri)) {
+  if (isBlockFile(uri, config)) {
+    let templateFsPath = transformer.blockToTemplate(fsPath);
     return {
       blockFsPath: fsPath,
       blockUri: uri,
-      templateFsPath: transformer.blockToTemplate(fsPath),
-      templateUri: URI.file(transformer.blockToTemplate(fsPath)).toString(),
+      templateFsPath,
+      templateUri: templateFsPath && URI.file(templateFsPath).toString(),
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8501,6 +8501,11 @@ glob-base@^0.3.0:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
 
+glob-escape@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/glob-escape/-/glob-escape-0.0.2.tgz#9c27f7821ed1c1377582f3efd9558e3f675628ed"
+  integrity sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0=
+
 glob-parent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
@@ -8559,6 +8564,18 @@ glob@^5.0.10, glob@^5.0.15:
 glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,21 +37,11 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.4", "@babel/generator@^7.6.0":
+"@babel/generator@^7.4.4", "@babel/generator@^7.5.5", "@babel/generator@^7.6.0":
   version "7.6.0"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
   dependencies:
     "@babel/types" "^7.6.0"
-    jsesc "^2.5.1"
-    lodash "^4.17.13"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-"@babel/generator@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
-  dependencies:
-    "@babel/types" "^7.5.5"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -220,15 +210,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
-
-"@babel/parser@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
-
-"@babel/parser@^7.6.0":
+"@babel/parser@^7.4.4", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5", "@babel/parser@^7.6.0":
   version "7.6.0"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
 
@@ -613,28 +595,14 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
-  version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
-"@babel/runtime@^7.6.3":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.6.3":
   version "7.7.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz#111a78002a5c25fc8e3361bedc9529c696b85a6a"
   integrity sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/template@^7.1.0", "@babel/template@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.4.4"
-    "@babel/types" "^7.4.4"
-
-"@babel/template@^7.6.0":
+"@babel/template@^7.1.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
   dependencies:
@@ -642,21 +610,7 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4":
-  version "7.4.5"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.4.4"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.4.5"
-    "@babel/types" "^7.4.4"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.11"
-
-"@babel/traverse@^7.4.5", "@babel/traverse@^7.6.0":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.4.5", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
   version "7.6.0"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
   dependencies:
@@ -670,29 +624,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/traverse@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
-  dependencies:
-    "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.5.5"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.5.5"
-    "@babel/types" "^7.5.5"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.13"
-
-"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.6.0":
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   dependencies:
@@ -1123,11 +1055,7 @@
   dependencies:
     "@glimmer/wire-format" "^0.34.8"
 
-"@glimmer/interfaces@^0.42.0":
-  version "0.42.0"
-  resolved "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.42.0.tgz#525f5352dd78011eef7b3eb0e3fb61b981c94319"
-
-"@glimmer/interfaces@^0.42.1":
+"@glimmer/interfaces@^0.42.0", "@glimmer/interfaces@^0.42.1":
   version "0.42.1"
   resolved "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.42.1.tgz#dff06df250165bdaf00221df2080f4e69fc4d117"
 
@@ -1281,16 +1209,7 @@
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.5.3"
 
-"@glimmer/syntax@^0.42.0":
-  version "0.42.0"
-  resolved "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.42.0.tgz#65d38f6f6339e0e00cfbb34bc08ed3ff94f080c6"
-  dependencies:
-    "@glimmer/interfaces" "^0.42.0"
-    "@glimmer/util" "^0.42.0"
-    handlebars "^4.0.13"
-    simple-html-tokenizer "^0.5.8"
-
-"@glimmer/syntax@^0.42.1":
+"@glimmer/syntax@^0.42.0", "@glimmer/syntax@^0.42.1":
   version "0.42.1"
   resolved "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.42.1.tgz#b1cd2afebbec2aec988cd12fe2f496710e3f55eb"
   dependencies:
@@ -1311,11 +1230,7 @@
   version "0.34.8"
   resolved "https://registry.npmjs.org/@glimmer/util/-/util-0.34.8.tgz#0f1349b3134bb55d4887da73919863401647525b"
 
-"@glimmer/util@^0.42.0":
-  version "0.42.0"
-  resolved "https://registry.npmjs.org/@glimmer/util/-/util-0.42.0.tgz#3f3a647ecaa16bbe4fc0545923d3b0a527319d78"
-
-"@glimmer/util@^0.42.1":
+"@glimmer/util@^0.42.0", "@glimmer/util@^0.42.1":
   version "0.42.1"
   resolved "https://registry.npmjs.org/@glimmer/util/-/util-0.42.1.tgz#8c768c8971d8897a0c63411a09a20ea825b5efb9"
 
@@ -2250,14 +2165,10 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
+"@types/lodash@*", "@types/lodash@^4.14.110":
   version "4.14.145"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.145.tgz#abcafe85788f1392c5d5a144142aaf8529ad6bb9"
   integrity sha512-7lX5bZFO3YG3AG0XVIm5L1SB6wDLtuaJksTkTWrux3/XwCZgw3MPWZBt3Jgj0w98uqUXWVypT2msxo0A1t22lw==
-
-"@types/lodash@^4.14.110":
-  version "4.14.123"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
 
 "@types/marked@^0.4.0":
   version "0.4.2"
@@ -3250,17 +3161,11 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.12.0:
+babel-plugin-ember-modules-api-polyfill@^2.12.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
   version "2.12.0"
   resolved "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.12.0.tgz#a5e703205ba4e625a7fab9bb1aea64ef3222cf75"
   dependencies:
     ember-rfc176-data "^0.3.12"
-
-babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
-  dependencies:
-    ember-rfc176-data "^0.3.9"
 
 babel-plugin-external-helpers@^6.22.0:
   version "6.22.0"
@@ -3911,11 +3816,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.4.7, bluebird@^3.5.1:
-  version "3.5.4"
-  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
-
-bluebird@^3.5.3, bluebird@^3.5.5:
+bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.4.7, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
 
@@ -5085,11 +4986,7 @@ chokidar@^2.0.2:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chownr@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
-
-chownr@^1.1.2:
+chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
 
@@ -5487,17 +5384,7 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-console-ui@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/console-ui/-/console-ui-3.0.4.tgz#1df0b003ea7b6adcda3d2f781f567b3b75ee7cbb"
-  dependencies:
-    chalk "^2.1.0"
-    inquirer "^6"
-    json-stable-stringify "^1.0.1"
-    ora "^3.4.0"
-    through2 "^3.0.1"
-
-console-ui@^3.0.4:
+console-ui@^3.0.2, console-ui@^3.0.4:
   version "3.1.1"
   resolved "https://registry.npmjs.org/console-ui/-/console-ui-3.1.1.tgz#681a0414e8b0a23ed679d0a2802e39d920801171"
   dependencies:
@@ -5708,22 +5595,13 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
+cosmiconfig@^5.1.0, cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   dependencies:
     import-fresh "^2.0.0"
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
-    parse-json "^4.0.0"
-
-cosmiconfig@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
-  dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
 cosmiconfig@^6.0.0:
@@ -6420,11 +6298,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
-  version "1.3.129"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.129.tgz#bff32e1840775554aafa301e9dc5002d565aae80"
-
-electron-to-chromium@^1.3.191:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.242"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.242.tgz#58d23cdc254d109d4839f3ae5d9e61846f80a234"
 
@@ -6488,7 +6362,7 @@ ember-cli-babel-plugin-helpers@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
 
-ember-cli-babel@7.11.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.8.0:
+ember-cli-babel@7.11.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.11.0"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.11.0.tgz#a2f4e4f123a4690968b512b87b4ff4bfa57ec244"
   dependencies:
@@ -6530,32 +6404,6 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     broccoli-source "^1.1.0"
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.2"
-    semver "^5.5.0"
-
-ember-cli-babel@^7.7.3:
-  version "7.8.0"
-  resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz#e596500eca0f5a7c9aaee755f803d1542f578acf"
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.3.4"
-    "@babel/plugin-proposal-decorators" "^7.3.0"
-    "@babel/plugin-transform-modules-amd" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.2.0"
-    "@babel/polyfill" "^7.0.0"
-    "@babel/preset-env" "^7.0.0"
-    "@babel/runtime" "^7.2.0"
-    amd-name-resolver "^1.2.1"
-    babel-plugin-debug-macros "^0.3.0"
-    babel-plugin-ember-modules-api-polyfill "^2.9.0"
-    babel-plugin-module-resolver "^3.1.1"
-    broccoli-babel-transpiler "^7.1.2"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.1"
-    broccoli-source "^1.1.0"
-    clone "^2.1.2"
-    ember-cli-babel-plugin-helpers "^1.1.0"
-    ember-cli-version-checker "^2.1.2"
-    ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
 ember-cli-broccoli-sane-watcher@^3.0.0:
@@ -6724,103 +6572,7 @@ ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.1.3:
     resolve-package-path "^1.2.6"
     semver "^5.6.0"
 
-ember-cli@*:
-  version "3.10.1"
-  resolved "https://registry.npmjs.org/ember-cli/-/ember-cli-3.10.1.tgz#068b63bab00ec8a229097d45b809ccc5e1a9dd53"
-  dependencies:
-    "@babel/core" "^7.4.3"
-    "@babel/plugin-transform-modules-amd" "^7.2.0"
-    amd-name-resolver "^1.3.1"
-    babel-plugin-module-resolver "^3.2.0"
-    bower-config "^1.4.1"
-    bower-endpoint-parser "0.2.2"
-    broccoli "^2.3.0"
-    broccoli-amd-funnel "^2.0.1"
-    broccoli-babel-transpiler "^7.2.0"
-    broccoli-builder "^0.18.14"
-    broccoli-concat "^3.7.3"
-    broccoli-config-loader "^1.0.1"
-    broccoli-config-replace "^1.1.2"
-    broccoli-debug "^0.6.5"
-    broccoli-funnel "^2.0.2"
-    broccoli-funnel-reducer "^1.0.0"
-    broccoli-merge-trees "^3.0.2"
-    broccoli-middleware "^2.0.1"
-    broccoli-module-normalizer "^1.3.0"
-    broccoli-module-unification-reexporter "^1.0.0"
-    broccoli-source "^1.1.0"
-    broccoli-stew "^2.1.0"
-    calculate-cache-key-for-tree "^2.0.0"
-    capture-exit "^2.0.0"
-    chalk "^2.4.2"
-    ci-info "^2.0.0"
-    clean-base-url "^1.0.0"
-    compression "^1.7.4"
-    configstore "^4.0.0"
-    console-ui "^3.0.2"
-    core-object "^3.1.5"
-    dag-map "^2.0.2"
-    diff "^4.0.1"
-    ember-cli-broccoli-sane-watcher "^3.0.0"
-    ember-cli-is-package-missing "^1.0.0"
-    ember-cli-lodash-subset "^2.0.1"
-    ember-cli-normalize-entity-name "^1.0.0"
-    ember-cli-preprocess-registry "^3.3.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-source-channel-url "^1.1.0"
-    ensure-posix-path "^1.0.2"
-    execa "^1.0.0"
-    exit "^0.1.2"
-    express "^4.16.4"
-    filesize "^4.1.2"
-    find-up "^3.0.0"
-    find-yarn-workspace-root "^1.2.1"
-    fs-extra "^7.0.1"
-    fs-tree-diff "^2.0.0"
-    get-caller-file "^2.0.5"
-    git-repo-info "^2.1.0"
-    glob "^7.1.3"
-    heimdalljs "^0.2.6"
-    heimdalljs-fs-monitor "^0.2.2"
-    heimdalljs-graph "^0.3.5"
-    heimdalljs-logger "^0.1.10"
-    http-proxy "^1.17.0"
-    inflection "^1.12.0"
-    is-git-url "^1.0.0"
-    isbinaryfile "^3.0.3"
-    js-yaml "^3.13.1"
-    json-stable-stringify "^1.0.1"
-    leek "0.0.24"
-    lodash.template "^4.4.0"
-    markdown-it "^8.4.2"
-    markdown-it-terminal "0.1.0"
-    minimatch "^3.0.4"
-    morgan "^1.9.1"
-    nopt "^3.0.6"
-    npm-package-arg "^6.1.0"
-    p-defer "^2.1.0"
-    portfinder "^1.0.20"
-    promise-map-series "^0.2.3"
-    quick-temp "^0.1.8"
-    resolve "^1.10.0"
-    resolve-package-path "^1.2.6"
-    rsvp "^4.8.4"
-    sane "^4.1.0"
-    semver "^6.0.0"
-    silent-error "^1.1.1"
-    sort-package-json "^1.22.1"
-    symlink-or-copy "^1.2.0"
-    temp "0.9.0"
-    testem "^2.14.0"
-    tiny-lr "^1.1.1"
-    tree-sync "^1.4.0"
-    uuid "^3.3.2"
-    validate-npm-package-name "^3.0.0"
-    walk-sync "^1.1.3"
-    watch-detector "^0.1.0"
-    yam "^1.0.0"
-
-ember-cli@~3.11:
+ember-cli@*, ember-cli@~3.11:
   version "3.11.0"
   resolved "https://registry.npmjs.org/ember-cli/-/ember-cli-3.11.0.tgz#05c055fde0803b2f4034a3b5a68daaed408e632d"
   dependencies:
@@ -8221,17 +7973,7 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
 
-fs-tree-diff@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.0.tgz#3c74e8219e4174690e85190b29ab4fd4a916744a"
-  dependencies:
-    "@types/symlink-or-copy" "^1.2.0"
-    heimdalljs-logger "^0.1.7"
-    object-assign "^4.1.0"
-    path-posix "^1.0.0"
-    symlink-or-copy "^1.1.8"
-
-fs-tree-diff@^2.0.1:
+fs-tree-diff@^2.0.0, fs-tree-diff@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz#343e4745ab435ec39ebac5f9059ad919cd034afa"
   dependencies:
@@ -8540,7 +8282,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
+glob@7.1.3:
   version "7.1.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -8561,18 +8303,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.4:
-  version "7.1.4"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -8723,11 +8454,7 @@ got@^8.0.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.15"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-
-graceful-fs@^4.1.15, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
   version "4.2.2"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
 
@@ -9192,14 +8919,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
   integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
@@ -10700,11 +10420,11 @@ lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
-lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
+lodash@4.17.11:
   version "4.17.11"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.7.14:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.7.14, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
@@ -11149,14 +10869,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.0, minipass@^2.2.1, minipass@^2.3.4:
-  version "2.3.5"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minipass@^2.3.5:
+minipass@^2.2.0, minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
   version "2.4.0"
   resolved "https://registry.npmjs.org/minipass/-/minipass-2.4.0.tgz#38f0af94f42fb6f34d3d7d82a90e2c99cd3ff485"
   dependencies:
@@ -11567,9 +11280,10 @@ node-releases@^1.1.25:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
+node-sass@^4.12.0, node-sass@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
+  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -11578,7 +11292,7 @@ node-sass@^4.12.0:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.13.2"
@@ -11672,14 +11386,7 @@ npm-lifecycle@^3.1.2:
     semver "^5.5.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-
-npm-packlist@^1.4.4:
+npm-packlist@^1.1.6, npm-packlist@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz#866224233850ac534b63d1a6e76050092b5d2f44"
   dependencies:
@@ -13685,13 +13392,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.11.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.11.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   dependencies:
@@ -13724,15 +13425,15 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+rimraf@2.6.3, rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   dependencies:
     glob "^7.1.3"
 
@@ -15009,19 +14710,7 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4:
-  version "4.4.8"
-  resolved "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.3.4"
-    minizlib "^1.1.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.2"
-
-tar@^4.4.10, tar@^4.4.8:
+tar@^4, tar@^4.4.10, tar@^4.4.8:
   version "4.4.10"
   resolved "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
   dependencies:


### PR DESCRIPTION
This PR adds basic support for any preprocessors that are set up in the css-blocks' configuration file. Because any extension is technically supported, we have to go to the disk to see what files actually exist according to expected naming conventions so that we can return the path to the correct file. Stylesheets that appear to be block files (e.g. named `*.block.*`) but aren't supported by the preprocessor configuration are basically ignored right now because otherwise CSS Blocks would just throw an error if we tried to parse it.

TODO:
- [x] Add Tests