### PR TITLE
chore: Clean up ember test logs.

### DIFF
--- a/packages/@css-blocks/ember-cli/testem.js
+++ b/packages/@css-blocks/ember-cli/testem.js
@@ -1,6 +1,9 @@
 module.exports = {
-  test_page: 'tests/index.html?hidepassed',
+  test_page: 'tests/index.html?hidepassed&nolint',
   disable_watching: true,
+  // only emit logs for failed tests
+  // https://github.com/testem/testem#tap-options
+  tap_quiet_logs: true,
   launch_in_ci: [
     'Chrome'
   ],

--- a/packages/@css-blocks/ember-cli/tests/dummy/app/initializers/main.js
+++ b/packages/@css-blocks/ember-cli/tests/dummy/app/initializers/main.js
@@ -1,0 +1,21 @@
+import { registerDeprecationHandler } from '@ember/debug';
+
+const DEPRECATIONS_TO_SILENCE = {
+  'ember-views.curly-components.jquery-element': true,
+};
+
+function shouldSilenceDeprecationById(deprecationId = '') {
+  return DEPRECATIONS_TO_SILENCE[deprecationId];
+}
+
+export function initialize() {
+  registerDeprecationHandler((message, options, next) => {
+    if (options && shouldSilenceDeprecationById(options.id)) {
+      return;
+    } else {
+      next(message, options);
+    }
+  });
+}
+
+export default { initialize };

--- a/packages/@css-blocks/ember-cli/tests/test-helper.js
+++ b/packages/@css-blocks/ember-cli/tests/test-helper.js
@@ -5,4 +5,8 @@ import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
 
-start();
+start({
+  // removes the additional framework onerror tests which are added by default
+  // https://github.com/emberjs/ember-qunit/blob/master/tests/unit/setup-ember-onerror-validation-test.js
+  setupEmberOnerrorValidation: false,
+});


### PR DESCRIPTION
The test logs for the ember-cli package are currently very noisy. This
silences the jquery deprecation warning and removes extraneous tests
for lint errors and ember onerror.