### PR TITLE
fix: Removing invalid paths from the package.json.

### DIFF
--- a/packages/@css-blocks/ember-cli/ember-cli-build.js
+++ b/packages/@css-blocks/ember-cli/ember-cli-build.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const Funnel = require('broccoli-funnel');
+const MergeTrees = require('broccoli-merge-trees');
+const path = require('path');
 
 module.exports = function(defaults) {
 
@@ -16,6 +19,8 @@ module.exports = function(defaults) {
     }
   });
 
+  let addonTree = new Funnel(path.resolve(__dirname, './tests/dummy/lib/in-repo-addon'));
+
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`
@@ -23,5 +28,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  return new MergeTrees([app.toTree(), addonTree]);
 };

--- a/packages/@css-blocks/ember-cli/ember-cli-build.js
+++ b/packages/@css-blocks/ember-cli/ember-cli-build.js
@@ -1,9 +1,6 @@
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-const Funnel = require('broccoli-funnel');
-const MergeTrees = require('broccoli-merge-trees');
-const path = require('path');
 
 module.exports = function(defaults) {
 
@@ -19,8 +16,6 @@ module.exports = function(defaults) {
     }
   });
 
-  let addonTree = new Funnel(path.resolve(__dirname, './tests/dummy/lib/in-repo-addon'));
-
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`
@@ -28,5 +23,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return new MergeTrees([app.toTree(), addonTree]);
+  return app.toTree();
 };

--- a/packages/@css-blocks/ember-cli/package.json
+++ b/packages/@css-blocks/ember-cli/package.json
@@ -57,9 +57,6 @@
     "ember-try": "^1.1.0",
     "eslint-plugin-ember": "^7.0.0",
     "eslint-plugin-node": "^9.0.0",
-    "in-repo-addon": "link:./tests/dummy/lib/in-repo-addon",
-    "in-repo-engine": "link:./tests/dummy/lib/in-repo-engine",
-    "in-repo-lazy-engine": "link:./tests/dummy/lib/in-repo-lazy-engine",
     "loader.js": "^4.7.0"
   },
   "engines": {

--- a/packages/@css-blocks/ember-cli/tests/dummy/lib/in-repo-engine/package.json
+++ b/packages/@css-blocks/ember-cli/tests/dummy/lib/in-repo-engine/package.json
@@ -9,7 +9,11 @@
     "@css-blocks/ember-cli": "^1.0.0-alpha.0",
     "ember-cli": "*",
     "ember-cli-htmlbars": "*",
-    "ember-cli-babel": "^6.16.0",
-    "in-repo-addon": "link:./tests/dummy/lib/in-repo-addon"
+    "ember-cli-babel": "^6.16.0"
+  },
+  "ember-addon": {
+    "paths": [
+      "../in-repo-addon"
+    ]
   }
 }


### PR DESCRIPTION
This fixes the invalid config error in ember-cli>v3.15.