### PR TITLE
fix(ember-cli): Fixes #365, now handles the promise from config.search.

### DIFF
--- a/packages/@css-blocks/ember-cli/index.js
+++ b/packages/@css-blocks/ember-cli/index.js
@@ -309,7 +309,12 @@ module.exports = {
     options.optimization || (options.optimization = {});
 
     if (!options.parserOpts) {
-      options.parserOpts = config.search(rootDir) || {};
+      // await the search
+      // if opts is blank/falsey or on error
+      // will default to empty object
+      options.parserOpts = await config.search(rootDir)
+      .catch(e => ({}))
+      .then(opts => opts || {});
     }
 
     // Use the node importer by default.

--- a/packages/@css-blocks/ember-cli/index.js
+++ b/packages/@css-blocks/ember-cli/index.js
@@ -152,7 +152,7 @@ module.exports = {
     delete this.addonPackages["in-repo-lazy-engine"];
   },
 
-  included(parent) {
+  async included(parent) {
     this._super.included.apply(this, arguments);
 
     // Engines' children are initialized twice, once by
@@ -166,7 +166,7 @@ module.exports = {
     let env = this.env = this.getEnv(parent);
 
     // Fetch and validate user-provided options.
-    let options = this._options = this.getOptions(env);
+    let options = this._options = await this.getOptions(env);
 
     let isApp = env.app === parent;
 
@@ -294,7 +294,7 @@ module.exports = {
     };
   },
 
-  getOptions(env) {
+  async getOptions(env) {
 
     let { isEmber, app, rootDir, modulePrefix } = env;
 


### PR DESCRIPTION
Fixes #365. 

Used await + promise syntax for defaults and await error fallback