### PR TITLE
Add style-of helper for glimmer.

### DIFF
--- a/packages/@css-blocks/glimmer/.vscode/launch.json
+++ b/packages/@css-blocks/glimmer/.vscode/launch.json
@@ -10,9 +10,9 @@
       "request": "launch",
       "name": "Launch Program",
       "preLaunchTask": "compile",
-      "program": "${workspaceRoot}/node_modules/.bin/_mocha",
+      "program": "${workspaceRoot}/../../../node_modules/.bin/_mocha",
       "args": [
-        "dist/test",
+        "dist/cjs/test",
         "--opts",
         "test/mocha.opts"
       ],

--- a/packages/@css-blocks/glimmer/src/Analyzer.ts
+++ b/packages/@css-blocks/glimmer/src/Analyzer.ts
@@ -13,8 +13,7 @@ import { TemplateIntegrationOptions } from "@opticss/template-api";
 import * as debugGenerator from "debug";
 import * as fs from "fs";
 
-import { ElementAnalyzer } from "./ElementAnalyzer";
-import { isEmberBuiltIn } from "./EmberBuiltins";
+import { ElementAnalyzer, isAnalyzedHelper } from "./ElementAnalyzer";
 import { Resolver } from "./Resolver";
 import { TEMPLATE_TYPE } from "./Template";
 
@@ -124,8 +123,7 @@ export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
     let elementAnalyzer = new ElementAnalyzer(analysis, this.cssBlocksOptions);
     traverse(ast, {
       MustacheStatement(node: AST.MustacheStatement) {
-        const name = node.path.original;
-        if (!isEmberBuiltIn(name)) { return; }
+        if (!isAnalyzedHelper(node)) { return; }
         elementCount++;
         const atRootElement = (elementCount === 1);
         const element = elementAnalyzer.analyze(node, atRootElement);
@@ -133,8 +131,7 @@ export class GlimmerAnalyzer extends Analyzer<TEMPLATE_TYPE> {
       },
 
       BlockStatement(node: AST.BlockStatement) {
-        const name = node.path.original;
-        if (!isEmberBuiltIn(name)) { return; }
+        if (!isAnalyzedHelper(node)) { return; }
         elementCount++;
         const atRootElement = (elementCount === 1);
         const element = elementAnalyzer.analyze(node, atRootElement);

--- a/packages/@css-blocks/glimmer/src/EmberBuiltins.ts
+++ b/packages/@css-blocks/glimmer/src/EmberBuiltins.ts
@@ -1,3 +1,7 @@
+import { AST } from "@glimmer/syntax";
+
+import { isBlockStatement, isMustacheStatement } from "./utils";
+
 /**
  * Ember Built-Ins are components that should be analyzed like regular
  * elements. The Analyzer and Rewriter will process components defined
@@ -21,6 +25,15 @@ const BUILT_INS: IBuiltIns = {
 
 export type BuiltIns = keyof IBuiltIns;
 
+export function isEmberBuiltInNode(node: AST.Node): node is AST.BlockStatement | AST.MustacheStatement {
+  if (isBlockStatement(node) || isMustacheStatement(node)) {
+    let name = node.path.original;
+    if (typeof name === "string" && BUILT_INS[name]) {
+      return true;
+    }
+  }
+  return false;
+}
 export function isEmberBuiltIn(name: unknown): name is keyof IBuiltIns {
   if (typeof name === "string" && BUILT_INS[name]) { return true; }
   return false;

--- a/packages/@css-blocks/glimmer/src/utils.ts
+++ b/packages/@css-blocks/glimmer/src/utils.ts
@@ -51,9 +51,24 @@ export function isBooleanLiteral(value: AST.Node | undefined): value is AST.Bool
 export function isMustacheStatement(value: AST.Node | undefined): value is AST.MustacheStatement {
   return !!value && value.type === "MustacheStatement";
 }
+export function isBlockStatement(value: AST.Node | undefined): value is AST.BlockStatement {
+  return !!value && value.type === "BlockStatement";
+}
 export function isSubExpression(value: AST.Node | undefined): value is AST.SubExpression {
   return !!value && value.type === "SubExpression";
 }
 export function isElementNode(value: AST.Node | undefined): value is AST.ElementNode {
   return !!value && value.type === "ElementNode";
+}
+export function isNumberLiteral(value: AST.Node | undefined): value is AST.NumberLiteral {
+  return !!value && value.type === "NumberLiteral";
+}
+export function isNullLiteral(value: AST.Node | undefined): value is AST.NullLiteral {
+  return !!value && value.type === "NullLiteral";
+}
+export function isUndefinedLiteral(value: AST.Node | undefined): value is AST.UndefinedLiteral {
+  return !!value && value.type === "UndefinedLiteral";
+}
+export function isPathExpression(value: AST.Node | undefined): value is AST.PathExpression {
+  return !!value && value.type === "PathExpression";
 }

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-style-helper/header.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-style-helper/header.css
@@ -1,0 +1,15 @@
+:scope {
+   font-size: 18px;
+}
+
+.emphasis {
+    font-style: italic;
+}
+
+.emphasis[style=bold] {
+    font-weight: bold;
+}
+
+.emphasis[style=italic] {
+    font-style: italic;
+}

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-style-helper/stylesheet.css
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-style-helper/stylesheet.css
@@ -1,0 +1,14 @@
+@export h from "./header.css";
+
+:scope {
+    color: red;
+}
+
+.world {
+    border: 1px solid black;
+}
+
+.world[thick] {
+    border-width: 3px;
+}
+

--- a/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-style-helper/template.hbs
+++ b/packages/@css-blocks/glimmer/test/fixtures/styled-app/src/ui/components/with-style-helper/template.hbs
@@ -1,0 +1,3 @@
+<div>
+  <h1 h:scope>Hello, <World cssClass={{style-of block:class="world" h:class="emphasis" block:thick=isThick h:style=textStyle}} />!</h1>
+</div>

--- a/packages/@css-blocks/glimmer/test/template-rewrite-test.ts
+++ b/packages/@css-blocks/glimmer/test/template-rewrite-test.ts
@@ -98,6 +98,18 @@ describe("Template Rewriting", function() {
     `));
   });
 
+  it("rewrites styles with the style-of helper", async function() {
+    let projectDir = fixture("styled-app");
+    let analyzer = new GlimmerAnalyzer(new BlockFactory({}), {}, moduleConfig);
+    let templatePath = fixture("styled-app/src/ui/components/with-style-helper/template.hbs");
+    let result = await pipeline(projectDir, analyzer, "with-style-helper", templatePath);
+    assert.deepEqual(minify(print(result.ast)), minify(`
+      <div class="b">
+        <h1 class="e">Hello, <World cssClass={{-css-blocks-concat (-css-blocks-concat "c f" " " (-css-blocks-classnames 2 3 2 isThick 1 2 4 2 1 (textStyle) "bold" 1 0 "italic" 1 1 "g" 0 "f" 1 "d" 2))}} />!</h1>
+      </div>
+    `));
+  });
+
   it("rewrites styles with block aliases", async function() {
     let projectDir = fixture("styled-app");
     let analyzer = new GlimmerAnalyzer(new BlockFactory({}), {}, moduleConfig);


### PR DESCRIPTION
There is a new synthetic helper for css-blocks in glimmer and ember applications called `style-of`.

Original Specification is at: https://github.com/linkedin/css-blocks/issues/383

The parameters and hash arguments to a `style-of` helper invocation are analyzed as if the helper invocation is an element or component invocation. The arguments to `style-of` can be dynamic in the same way that attributes can be dynamic.

The return value of the `style-of` helper is a string that can be set to an html `class` attribute. This value should be considered opaque. Do not try to manipulate it or depend on the value inside it.

Merging the class names from CSS Blocks with class names from styles not managed by CSS Blocks may result in unexpected behavior, especially with opticss enabled.

Closes #383.