### PR TITLE
feat(eyeglass): Adds new package that enables simple Eyeglass support.

### DIFF
--- a/css-blocks.code-workspace
+++ b/css-blocks.code-workspace
@@ -51,6 +51,9 @@
 		},
 		{
 			"path": "packages/@css-blocks/bem-to-blocks"
+		},
+		{
+			"path": "packages/@css-blocks/eyeglass"
 		}
 	],
 	"settings": {

--- a/packages/@css-blocks/eyeglass/CHANGELOG.md
+++ b/packages/@css-blocks/eyeglass/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/@css-blocks/eyeglass/README.md
+++ b/packages/@css-blocks/eyeglass/README.md
@@ -1,0 +1,28 @@
+# CSS Blocks Eyeglass Integration
+This package provides an easy way to integrate your CSS Blocks code with the Sass module manager [Eyeglass](https://github.com/linkedin/eyeglass).
+
+## Installation
+
+`npm install @css-blocks/eyeglass`
+
+## Usage
+
+Here's an example `css-blocks.config.js` file using this package. 
+
+```js
+import sass from "node-sass";
+import eyeglass from "eyeglass";
+import { adaptor } from "@css-blocks/eyeglass";
+
+const sassOptions = {
+  outputStyle: "expanded"
+};
+
+const scss = adaptor(sass, eyeglass, sassOptions);
+
+module.exports = {
+  preprocessors: { scss }
+};
+```
+
+An important thing to notice here is that this adapter _does not provide Eyeglass for you_. Instead we use the module instance you pass into the adaptor. This means you're not tied whatever version of Eyeglass (or Sass) this package would include!

--- a/packages/@css-blocks/eyeglass/package.json
+++ b/packages/@css-blocks/eyeglass/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@css-blocks/eyeglass",
+  "author": "Gregory Wild-Smith <gwildsmith@linkedin.com>",
+  "description": "Tool to provide easy interoperation with the Eyeglass SASS module manager",
+  "license": "BSD-2-Clause",
+  "version": "1.0.0-alpha.7",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "bin",
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "readme": "README.md",
+  "keywords": [
+    "eyeglass",
+    "css blocks",
+    "css",
+    "blocks"
+  ],
+  "scripts": {
+    "test": "yarn run test:runner",
+    "test:runner": "mocha --opts test/mocha.opts dist/test",
+    "compile": "tsc --build",
+    "pretest": "yarn run compile",
+    "posttest": "yarn run lintfix",
+    "prepublish": "rm -rf dist && yarn run compile && yarn run lintall",
+    "lint": "tslint -t msbuild --project . -c tslint.cli.json",
+    "lintall": "tslint -t msbuild --project . -c tslint.release.json",
+    "lintfix": "tslint -t msbuild --project . -c tslint.cli.json --fix",
+    "coverage": "istanbul cover -i dist/src/**/*.js --dir ./build/coverage ../../../node_modules/mocha/bin/_mocha -- dist/test --opts test/mocha.opts",
+    "remap": "remap-istanbul -i build/coverage/coverage.json -o coverage -t html",
+    "watch": "watch 'yarn run test' src test --wait=1"
+  },
+  "bugs": {
+    "url": "https://github.com/linkedin/css-blocks/issues"
+  },
+  "repository": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/eyeglass",
+  "homepage": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/eyeglass#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {},
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
+  },
+  "volta": {
+    "node": "12.15.0",
+    "yarn": "1.22.0"
+  },
+  "devDependencies": {
+    "@types/node-sass": "^4.11.0",
+    "@types/sinon": "^7.5.1",
+    "eyeglass": "^2.4.2",
+    "mocha": "^6.1.4",
+    "node-sass": "^4.13.1",
+    "sinon": "^8.0.4"
+  }
+}

--- a/packages/@css-blocks/eyeglass/src/index.ts
+++ b/packages/@css-blocks/eyeglass/src/index.ts
@@ -1,0 +1,29 @@
+import { ProcessedFile } from "@css-blocks/core";
+import Eyeglass from "eyeglass"; // works, even tho a cjs export. huh.
+import { Options, Result, SassError } from "node-sass";
+import SassImplementation from "node-sass";
+
+export function adaptor(sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: Options = {}) {
+    return (file: string, data: string) => {
+        return new Promise<ProcessedFile>((resolve, reject) => {
+            const sassOptions = Object.assign(options, {
+                file,
+                data,
+                sourceMap: true,
+                outFile: file.replace(/scss$/, "css"),
+            });
+
+            sass.render(eyeglass(sassOptions), (err: SassError, res: Result): void => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({
+                        content: res.css.toString(),
+                        sourceMap: res.map.toString(),
+                        dependencies: res.stats.includedFiles,
+                    });
+                }
+            });
+        });
+    };
+  }

--- a/packages/@css-blocks/eyeglass/test/mocha.opts
+++ b/packages/@css-blocks/eyeglass/test/mocha.opts
@@ -1,0 +1,4 @@
+--reporter spec
+--require source-map-support/register
+--inline-diffs
+dist/test/*.js

--- a/packages/@css-blocks/eyeglass/test/package-test.ts
+++ b/packages/@css-blocks/eyeglass/test/package-test.ts
@@ -1,0 +1,113 @@
+
+import { expect } from "chai";
+import Eyeglass from "eyeglass";
+import { Result } from "node-sass";
+import SassImplementation = require("node-sass");
+import * as sinon from "sinon";
+
+import { adaptor } from "../src/";
+
+const fakeSass = {
+    render: sinon.spy(),
+} as unknown as typeof SassImplementation;
+const fakeEyeglass = sinon.spy() as unknown as typeof Eyeglass;
+
+// this is used later to generate test data.
+function string2buffer(str: string): ArrayBuffer {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const view = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    view[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+
+describe("@css-blocks/eyeglass", async () => {
+
+  afterEach(async () => {
+    (fakeSass.render as unknown as sinon.SinonSpy).resetHistory();
+    (fakeEyeglass as unknown as sinon.SinonSpy).resetHistory();
+  });
+
+  it("exports a function named adaptor that returns a function", async () => {
+    expect(adaptor).to.be.a("function");
+    expect(adaptor(fakeSass, fakeEyeglass)).to.be.a("function");
+  });
+
+  it("returned function returns a Promise when called", async () => {
+    const injector = adaptor(fakeSass, fakeEyeglass);
+    const result = injector("file", "data");
+
+    expect(result).to.be.a("promise");
+  });
+
+  it("calls the correct Eyeglass and Sass APIs", async () => {
+    const injector = adaptor(fakeSass, fakeEyeglass);
+    const result = injector("file", "data");
+
+    expect(result).to.be.a("promise");
+    sinon.assert.calledOnce(fakeSass.render as unknown as sinon.SinonSpy);
+    sinon.assert.calledOnce(fakeEyeglass as unknown as sinon.SinonSpy);
+  });
+
+  it("injects the correct options while not overriding others", async () => {
+    const dummyOptions = {
+      file: "wrong.scss",
+      data: "wrong",
+      sourceMap: false,
+      outFile: "wrong.css",
+      precision: 42,
+    };
+    const injector = adaptor(fakeSass, fakeEyeglass, dummyOptions);
+    const result = injector("correct.scss", "correct");
+
+    expect(result).to.be.a("promise");
+    const spiedEyeglass = fakeEyeglass as unknown as sinon.SinonSpy;
+    // did it keep the extra argument?
+    sinon.assert.alwaysCalledWithMatch(spiedEyeglass, {precision: 42});
+    // did it override the right options?
+    sinon.assert.alwaysCalledWithMatch(spiedEyeglass, {file: "correct.scss", data: "correct", sourceMap: true, outFile: "correct.css"});
+  });
+
+  it("returns the correct data from the render callback", async () => {
+    const css = Buffer.from(string2buffer("css-data"));
+    const map = Buffer.from(string2buffer("map-data"));
+    const fakeResult: Result = {
+      css,
+      map,
+      stats: {
+        entry: "entry",
+        start: 0,
+        end: 1,
+        duration: 2,
+        includedFiles: ["files"],
+      },
+    };
+    const injector = adaptor(fakeSass, fakeEyeglass);
+    const result = injector("correct.scss", "correct");
+    const callback = (fakeSass.render as unknown as sinon.SinonSpy).args[0][1];
+    callback(undefined, fakeResult);
+
+    const output = await result;
+
+    expect(result).to.be.a("promise");
+    expect(callback).to.be.a("function");
+    expect(output.content).to.equal(css.toString());
+    expect(output.sourceMap).to.equal(map.toString());
+    expect(output.dependencies).to.be.an("array");
+    expect(output.dependencies && output.dependencies[0]).to.equal("files");
+  });
+  it("throws on error passed to render callback", async () => {
+    const injector = adaptor(fakeSass, fakeEyeglass);
+    const result = injector("correct.scss", "correct");
+    const callback = (fakeSass.render as unknown as sinon.SinonSpy).args[0][1];
+    callback("test error");
+    let output;
+    try {
+      output = await result;
+    } catch (err) {
+      expect(err).to.equal("test error");
+    }
+    expect(output).to.be.an("undefined");
+  });
+});

--- a/packages/@css-blocks/eyeglass/tsconfig.json
+++ b/packages/@css-blocks/eyeglass/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "baseUrl": "dist",
+    "paths": {
+      "sass": ["../../../node_modules/@types/node-sass"]
+    }
+  },
+  "references": [
+    {"path": "../core"}
+  ],
+  "include": [
+    "src",
+    "test"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/@css-blocks/eyeglass/tslint.cli.json
+++ b/packages/@css-blocks/eyeglass/tslint.cli.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": "@css-blocks/code-style/configs/tslint.cli.json"
+}

--- a/packages/@css-blocks/eyeglass/tslint.json
+++ b/packages/@css-blocks/eyeglass/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@css-blocks/code-style"
+}

--- a/packages/@css-blocks/eyeglass/tslint.release.json
+++ b/packages/@css-blocks/eyeglass/tslint.release.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": "@css-blocks/code-style/configs/tslint.release.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,6 +2276,7 @@
 "@types/node-sass@^4.11.0":
   version "4.11.0"
   resolved "https://registry.npmjs.org/@types/node-sass/-/node-sass-4.11.0.tgz#b0372075546e83f39df52bd37359eab00165a04d"
+  integrity sha512-uNpVWhwVmbB5luE7b8vxcJwu5np75YkVTBJS0O3ar+hrxqLfyhOKXg9NYBwJ6mMQX/V6/8d6mMZTB7x2r5x9Bw==
   dependencies:
     "@types/node" "*"
 
@@ -3940,6 +3941,13 @@ binary-extensions@^2.0.0:
 "binaryextensions@1 || 2":
   version "2.2.0"
   resolved "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.2.0.tgz#e7c6ba82d4f5f5758c26078fe8eea28881233311"
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bl@^3.0.0:
   version "3.0.0"
@@ -6073,6 +6081,14 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
+deasync@^0.1.13:
+  version "0.1.19"
+  resolved "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz#e7ea89fcc9ad483367e8a48fe78f508ca86286e8"
+  integrity sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^1.7.1"
+
 debug@2, debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -7119,6 +7135,11 @@ ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2, en
   version "1.1.1"
   resolved "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
 
+ensure-symlink@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/ensure-symlink/-/ensure-symlink-1.0.2.tgz#58ebc26d15a9539b9e79d00aa9623f8fa65ff18d"
+  integrity sha1-WOvCbRWpU5ueedAKqWI/j6Zf8Y0=
+
 entities@^1.1.1, entities@^1.1.2, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -7797,6 +7818,26 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
+eyeglass@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/eyeglass/-/eyeglass-2.4.2.tgz#a9d215e5fdde1a0cb7e53fe45909832f703fa264"
+  integrity sha512-V/sj+J6dQZf7AKHd/lLUbBgrDdHwbVeuKiYKuWQ8zNP6hi2urIgapRcMpBmlcsGDDr2Qd+8/1fla/0W4EaYJ4w==
+  dependencies:
+    archy "^1.0.0"
+    deasync "^0.1.13"
+    debug "^4.1.0"
+    ensure-symlink "^1.0.2"
+    fs-extra "^7.0.0"
+    glob "^7.1.0"
+    heimdalljs "^0.2.6"
+    json-stable-stringify "^1.0.1"
+    lodash.includes "^4.3.0"
+    lodash.merge "^4.6.1"
+    lru-cache "^5.1.1"
+    node-sass "^4.0.0 || ^3.10.1"
+    node-sass-utils "^1.1.2"
+    semver "^5.6.0"
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
@@ -7900,7 +7941,7 @@ file-loader@1.1.5:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-file-uri-to-path@1:
+file-uri-to-path@1, file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
 
@@ -8587,7 +8628,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   dependencies:
@@ -10704,6 +10745,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -10728,7 +10774,7 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.merge@^4.6.0, lodash.merge@^4.6.2:
+lodash.merge@^4.6.0, lodash.merge@^4.6.1, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
 
@@ -11533,6 +11579,11 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+node-addon-api@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
+  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
+
 node-environment-flags@1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
@@ -11655,6 +11706,34 @@ node-releases@^1.1.40:
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz#57674a82a37f812d18e3b26118aefaf53a00afed"
   dependencies:
     semver "^6.3.0"
+
+node-sass-utils@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/node-sass-utils/-/node-sass-utils-1.1.2.tgz#d03639cfa4fc962398ba3648ab466f0db7cc2131"
+  integrity sha1-0DY5z6T8liOYujZIq0ZvDbfMITE=
+
+"node-sass@^4.0.0 || ^3.10.1", node-sass@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
 
 node-sass@^4.12.0:
   version "4.13.0"


### PR DESCRIPTION
Fixes #398 

Should be a cleaner TS implementation than my previous PR (thanks for the feedback and help using Namespaces as types). I'm using Sinon spies in the tests, and because of that found I didn't need to use the module importer mock you mentioned (as rather than testing all of css-blocks in the unit tests I'm just testing what _this package_  takes in and puts out, as well as that the created functions are called). 

Code test coverage is 100%, which is nice.