### PR TITLE
feat: Compiled CSS importing in NodeJSImporter.

### DIFF
--- a/packages/@css-blocks/core/src/importing/BaseImporter.ts
+++ b/packages/@css-blocks/core/src/importing/BaseImporter.ts
@@ -2,7 +2,7 @@ import { Syntax } from "../BlockParser";
 import { ResolvedConfiguration } from "../configuration";
 import { REGEXP_COMMENT_DEFINITION_REF, REGEXP_COMMENT_FOOTER, REGEXP_COMMENT_HEADER } from "../PrecompiledDefinitions/compiled-comments";
 
-import { FileIdentifier, ImportedCompiledCssFileContents, ImportedFile, Importer } from "./Importer";
+import { FileIdentifier, ImportedCompiledCssFile, ImportedCompiledCssFileContents, ImportedFile, Importer } from "./Importer";
 
 /**
  * The BaseImporter is an abstract class that Importer implementations may extend from.
@@ -19,7 +19,7 @@ export abstract class BaseImporter implements Importer {
   /**
    * Import the file with the given metadata and return a string and meta data for it.
    */
-  abstract import(identifier: FileIdentifier, config: ResolvedConfiguration): Promise<ImportedFile>;
+  abstract import(identifier: FileIdentifier, config: ResolvedConfiguration): Promise<ImportedFile | ImportedCompiledCssFile>;
   /**
    * The default name of the block used unless the block specifies one itself.
    */

--- a/packages/@css-blocks/core/test/fixtures/compiledFileImporting/embedded/nav.css
+++ b/packages/@css-blocks/core/test/fixtures/compiledFileImporting/embedded/nav.css
@@ -1,0 +1,19 @@
+/* This is a test compiled css file. */
+/*#css-blocks 7d97e*/
+.nav-7d97e {
+  display: flex;
+}
+.nav-7d97e__entry {
+  flex: 1;
+}
+.nav-7d97e__entry--active {
+  font-weight: bold;
+}
+.nav-7d97e__entry--active.link-3c287 {
+  font-weight: bold;
+}
+.nav-7d97e__entry:hover {
+  text-shadow: 2px 2px 1px;
+}
+/*#blockDefinitionURL=data:text/css;base64,QGJsb2NrLXN5bnRheC12ZXJzaW9uIDE7CkBibG9jayBsaW5rIGZyb20gIi4uL3NoYXJlZC9saW5rLmNzcyI7CkBibG9jayBsaXN0IGZyb20gIi4uL3NoYXJlZC9saXN0LmNzcyI7CkBleHBvcnQgaXRlbSBmcm9tICIuLi9zaGFyZWQvaXRlbS5jc3MiOwoKOnNjb3BlIHsKICBibG9jay1pZDogIjdkOTdlIjsKICBibG9jay1jbGFzczogbmF2LTdkOTdlOwogIGJsb2NrLWludGVyZmFjZS1pbmRleDogMDsKICBibG9jay1hbGlhczogdG9wLW5hdjsKICBibG9jay1uYW1lOiBuYXY7CiAgZXh0ZW5kczogbGlzdDsKICBpbmhlcml0ZWQtc3R5bGVzOiAibGlzdFt0eXBlPW9yZGVyZWRdIiAxLCAibGlzdFt0eXBlPXVub3JkZXJlZF0iIDIsICJsaXN0W3R5cGU9aW5saW5lXSIgMywgImxpc3RbdHlwZT1ob3Jpem9udGFsXSIgNCwgImxpc3QuaXRlbSIgNSwgImxpc3QuaXRlbVtsYXN0XSIgNjsKfQoKLmVudHJ5IHsKICBibG9jay1pbnRlcmZhY2UtaW5kZXg6IDc7CiAgYmxvY2stYWxpYXM6IHRvcC1uYXYtZW50cnk7CiAgYmxvY2stY2xhc3M6IG5hdi03ZDk3ZV9fZW50cnk7Cn0KCi5lbnRyeVthY3RpdmVdIHsKICBibG9jay1pbnRlcmZhY2UtaW5kZXg6IDg7CiAgYmxvY2stY2xhc3M6IG5hdi03ZDk3ZV9fZW50cnktLWFjdGl2ZTsKICBmb250LXdlaWdodDogcmVzb2x2ZSgibGluayIpOwogIGZvbnQtd2VpZ2h0OiByZXNvbHZlLXNlbGYoKTsKfQ==*/
+/*#css-blocks end*/

--- a/packages/@css-blocks/core/test/fixtures/compiledFileImporting/expectedResults/expectedCssContents.txt
+++ b/packages/@css-blocks/core/test/fixtures/compiledFileImporting/expectedResults/expectedCssContents.txt
@@ -1,0 +1,15 @@
+.nav-7d97e {
+  display: flex;
+}
+.nav-7d97e__entry {
+  flex: 1;
+}
+.nav-7d97e__entry--active {
+  font-weight: bold;
+}
+.nav-7d97e__entry--active.link-3c287 {
+  font-weight: bold;
+}
+.nav-7d97e__entry:hover {
+  text-shadow: 2px 2px 1px;
+}

--- a/packages/@css-blocks/core/test/fixtures/compiledFileImporting/expectedResults/expectedDfnContents.txt
+++ b/packages/@css-blocks/core/test/fixtures/compiledFileImporting/expectedResults/expectedDfnContents.txt
@@ -1,0 +1,27 @@
+@block-syntax-version 1;
+@block link from "../shared/link.css";
+@block list from "../shared/list.css";
+@export item from "../shared/item.css";
+
+:scope {
+  block-id: "7d97e";
+  block-class: nav-7d97e;
+  block-interface-index: 0;
+  block-alias: top-nav;
+  block-name: nav;
+  extends: list;
+  inherited-styles: "list[type=ordered]" 1, "list[type=unordered]" 2, "list[type=inline]" 3, "list[type=horizontal]" 4, "list.item" 5, "list.item[last]" 6;
+}
+
+.entry {
+  block-interface-index: 7;
+  block-alias: top-nav-entry;
+  block-class: nav-7d97e__entry;
+}
+
+.entry[active] {
+  block-interface-index: 8;
+  block-class: nav-7d97e__entry--active;
+  font-weight: resolve("link");
+  font-weight: resolve-self();
+}

--- a/packages/@css-blocks/core/test/fixtures/compiledFileImporting/externaldef/nav.block.css
+++ b/packages/@css-blocks/core/test/fixtures/compiledFileImporting/externaldef/nav.block.css
@@ -1,0 +1,27 @@
+@block-syntax-version 1;
+@block link from "../shared/link.css";
+@block list from "../shared/list.css";
+@export item from "../shared/item.css";
+
+:scope {
+  block-id: "7d97e";
+  block-class: nav-7d97e;
+  block-interface-index: 0;
+  block-alias: top-nav;
+  block-name: nav;
+  extends: list;
+  inherited-styles: "list[type=ordered]" 1, "list[type=unordered]" 2, "list[type=inline]" 3, "list[type=horizontal]" 4, "list.item" 5, "list.item[last]" 6;
+}
+
+.entry {
+  block-interface-index: 7;
+  block-alias: top-nav-entry;
+  block-class: nav-7d97e__entry;
+}
+
+.entry[active] {
+  block-interface-index: 8;
+  block-class: nav-7d97e__entry--active;
+  font-weight: resolve("link");
+  font-weight: resolve-self();
+}

--- a/packages/@css-blocks/core/test/fixtures/compiledFileImporting/externaldef/nav.css
+++ b/packages/@css-blocks/core/test/fixtures/compiledFileImporting/externaldef/nav.css
@@ -1,0 +1,19 @@
+/* This is a test compiled css file. */
+/*#css-blocks 7d97e*/
+.nav-7d97e {
+  display: flex;
+}
+.nav-7d97e__entry {
+  flex: 1;
+}
+.nav-7d97e__entry--active {
+  font-weight: bold;
+}
+.nav-7d97e__entry--active.link-3c287 {
+  font-weight: bold;
+}
+.nav-7d97e__entry:hover {
+  text-shadow: 2px 2px 1px;
+}
+/*#blockDefinitionURL=nav.block.css*/
+/*#css-blocks end*/

--- a/packages/@css-blocks/core/test/importing-test.ts
+++ b/packages/@css-blocks/core/test/importing-test.ts
@@ -17,6 +17,7 @@ import {
 
 const FIXTURES = path.resolve(__dirname, "..", "..", "test", "fixtures");
 const FSI_FIXTURES = path.join(FIXTURES, "filesystemImporter");
+const COMPILED_CSS_FIXTURES = path.join(FIXTURES, "compiledFileImporting");
 const ALIAS_FIXTURES = path.join(FIXTURES, "pathAliasImporter");
 const NODE_MODULE_FIXTURES = path.join(FIXTURES, "nodeModuleImporter");
 
@@ -91,6 +92,60 @@ function testFSImporter(name: string, importer: Importer) {
         assert.equal(importedFile.syntax, Syntax.css);
       } else {
         assert.fail(importedFile.type, "ImportedFile", "Mismatched type given");
+      }
+    });
+    it("Can import Compiled CSS file with embedded definition data", async () => {
+      const EMBEDDED_DFN_FIXTURES = path.join(COMPILED_CSS_FIXTURES, "embedded");
+      const options = getConfiguration(EMBEDDED_DFN_FIXTURES);
+      const ident = importer.identifier(null, "nav.css", options);
+      const importedFile = await importer.import(ident, options);
+      if (importedFile.type === "ImportedCompiledCssFile") {
+        assert.equal(importedFile.identifier, ident);
+        assert.equal(importedFile.syntax, Syntax.css);
+        assert.equal(importedFile.blockId, "7d97e");
+        assert.deepEqual(
+          importedFile.cssContents.trim(),
+          fs.readFileSync(
+            path.join(COMPILED_CSS_FIXTURES, "expectedResults", "expectedCssContents.txt"),
+            "utf-8",
+          ).trim(),
+        );
+        assert.deepEqual(
+          importedFile.definitionContents.trim(),
+          fs.readFileSync(
+            path.join(COMPILED_CSS_FIXTURES, "expectedResults", "expectedDfnContents.txt"),
+            "utf-8",
+          ).trim(),
+        );
+      } else {
+        assert.fail(importedFile.type, "ImportedCompiledCssFile", "Mismatched type given");
+      }
+    });
+    it("Can import Compiled CSS file with external definition path", async () => {
+      const EXTERNAL_DFN_FIXTURES = path.join(COMPILED_CSS_FIXTURES, "externaldef");
+      const options = getConfiguration(EXTERNAL_DFN_FIXTURES);
+      const ident = importer.identifier(null, "nav.css", options);
+      const importedFile = await importer.import(ident, options);
+      if (importedFile.type === "ImportedCompiledCssFile") {
+        assert.equal(importedFile.identifier, ident);
+        assert.equal(importedFile.syntax, Syntax.css);
+        assert.equal(importedFile.blockId, "7d97e");
+        assert.deepEqual(
+          importedFile.cssContents.trim(),
+          fs.readFileSync(
+            path.join(COMPILED_CSS_FIXTURES, "expectedResults", "expectedCssContents.txt"),
+            "utf-8",
+          ).trim(),
+        );
+        assert.deepEqual(
+          importedFile.definitionContents.trim(),
+          fs.readFileSync(
+            path.join(COMPILED_CSS_FIXTURES, "expectedResults", "expectedDfnContents.txt"),
+            "utf-8",
+          ).trim(),
+        );
+      } else {
+        assert.fail(importedFile.type, "ImportedCompiledCssFile", "Mismatched type given");
       }
     });
   });


### PR DESCRIPTION
- Update import method in NodeJSImporter to support Compiled CSS files.
This update supports both inline definitions and definition files.
- Update tests to validate changes.