### PR TITLE
Block definition compiler

### DIFF
--- a/css-blocks.code-workspace
+++ b/css-blocks.code-workspace
@@ -57,6 +57,9 @@
 		},
 		{
 			"path": "packages/@css-blocks/ember"
+		},
+		{
+			"path": "packages/@css-blocks/ember-app"
 		}
 	],
 	"settings": {

--- a/packages/@css-blocks/core/.vscode/cSpell.json
+++ b/packages/@css-blocks/core/.vscode/cSpell.json
@@ -28,6 +28,7 @@
         "stateful",
         "Stmnt",
         "truthy",
+        "typeguards",
         "Validators"
     ],
     // flagWords - list of words to be always considered incorrect

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
@@ -208,6 +208,7 @@ export class BlockDefinitionCompiler {
     if (isBlockClass(style) && style.isRoot) {
       declarations.push(builders.declaration("block-id", `"${style.block.guid}"`));
       declarations.push(builders.declaration("block-name", `"${style.block.name}"`));
+      // TODO: inherited-styles
     }
 
     let compositions = new Array<string>();
@@ -229,12 +230,14 @@ export class BlockDefinitionCompiler {
     }
     return builders.rule(selectors, declarations);
   }
+
   /**
-   * Simple compositions (which apply to a single block class or attribute) are
-   * processed when we generate the rule for that style. The complex
-   * compositions which apply to the intersection of more than one attribute
-   * require the generation of ruleset that targets all of those attributes
-   * together.
+   * The complex compositions which apply to the intersection of more than one
+   * attribute require the generation of ruleset that targets all of those
+   * attributes together.
+   *
+   * Note: Simple compositions (which apply to a single block class or
+   * attribute) are processed when we generate the rule for that style.
    */
   complexCompositions(block: Block): Array<Rule<DefinitionAST>> {
     let complexCompositions: Dictionary<{ blockClass: BlockClass; attributes: AttrValue[]; paths: Array<string> }> = {};

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
@@ -1,27 +1,231 @@
 import { postcss } from "opticss";
 
-import { Block } from "../BlockTree";
+import { AttributeSelector, BlockExport, BlockReference, BlockSyntaxVersion, ClassSelector, Declaration, DefinitionAST, DefinitionRoot, ForeignAttributeSelector, GlobalDeclaration, LocalBlockExport, Mapper, Name, Rename, Rule, ScopeSelector, Selector, Visitor, builders, map as mapToDefinition, visit } from "../BlockParser/ast";
+import { BLOCK_GLOBAL } from "../BlockSyntax";
+import { Block, BlockClass, Style, isAttrValue, isBlockClass } from "../BlockTree";
 import { ResolvedConfiguration } from "../configuration";
 
 export const INLINE_DEFINITION_FILE = Symbol("Inline Definition");
 
-export type PathResolver = (config: ResolvedConfiguration, fromBlock: Block, toBlock: Block, fromPath: string) => string;
+export type PathResolver = (block: Block, fromPath: string) => string;
 
-export const filesystemPathResolver: PathResolver = (_config: ResolvedConfiguration, _fromBlock: Block, _toBlock: Block, fromPath: string): string => {
-  return fromPath.replace(".block", "");
-};
+class CompiledDefinitionMapper implements Mapper<DefinitionAST> {
+  pathResolver: PathResolver;
+  block: Block;
+  constructor(block: Block, pathResolver: PathResolver) {
+    this.block = block;
+    this.pathResolver = pathResolver;
+  }
+  BlockExport(fromPath: string, exports: Array<Name | Rename>) {
+    fromPath = this.pathResolver(this.block, fromPath);
+    return builders.blockExport(fromPath, exports);
+  }
+  BlockReference(fromPath: string, defaultName: string, references: Array<Name | Rename>) {
+    fromPath = this.pathResolver(this.block, fromPath);
+    return builders.blockReference(fromPath, defaultName, references);
+  }
+}
+
+class SelectorASTBuilder implements Visitor<DefinitionAST> {
+  selector: string;
+  constructor() {
+    this.selector = "";
+  }
+  AttributeSelector(attr: AttributeSelector): void {
+    this.selector += `[${attr.attribute}`;
+    if (attr.matches) {
+      this.selector += attr.matches.matcher;
+      this.selector += `"${attr.matches.value}"`;
+    }
+    this.selector += "]";
+  }
+  ForeignAttributeSelector(attr: ForeignAttributeSelector): void {
+    this.selector += `[${attr.ns}|${attr.attribute}`;
+    if (attr.matches) {
+      this.selector += attr.matches.matcher;
+      this.selector += `"${attr.matches.value}"`;
+    }
+    this.selector += "]";
+  }
+  ScopeSelector(_scopeSelector: ScopeSelector): void {
+    this.selector += `:scope`;
+  }
+  ClassSelector(classSelector: ClassSelector): void {
+    this.selector += `.${classSelector.name}`;
+  }
+}
+
+class CompiledDefinitionPostcssASTBuilder implements Visitor<DefinitionAST> {
+  postcss: typeof postcss;
+  root: postcss.Root;
+  currentRule: postcss.Rule | undefined;
+  constructor(postcssImpl: typeof postcss) {
+    this.postcss = postcssImpl;
+    this.root = this.postcss.root();
+  }
+
+  namedReferences(references: Array<Name | Rename>): string {
+    let result = "";
+    result += "(";
+    let prevRef = false;
+    for (let ref of references) {
+      if (prevRef) {
+        result += ", ";
+      }
+      result += ref.name;
+      if (ref.asName) {
+        result += ` as ${ref.asName}`;
+      }
+      prevRef = true;
+    }
+    result += ")";
+    return result;
+  }
+
+  BlockSyntaxVersion(blockSyntaxVersion: BlockSyntaxVersion): void {
+    this.root.append(this.postcss.atRule({
+      name: "block-syntax-version",
+      params: blockSyntaxVersion.version.toString(),
+    }));
+  }
+
+  BlockReference(blockReference: BlockReference): void {
+    let params = "";
+    if (blockReference.defaultName) {
+      params += blockReference.defaultName;
+    }
+    if (blockReference.defaultName && blockReference.references) {
+      params += ", ";
+    }
+    if (blockReference.references) {
+      params += this.namedReferences(blockReference.references);
+    }
+    params += ` from "${blockReference.fromPath}"`;
+    let atRule = this.postcss.atRule({
+      name: "block",
+      params,
+    });
+    this.root.append(atRule);
+  }
+
+  LocalBlockExport(localBlockExport: LocalBlockExport): void {
+    let params = this.namedReferences(localBlockExport.exports);
+    let atRule = this.postcss.atRule({
+      name: "export",
+      params,
+    });
+    this.root.append(atRule);
+  }
+
+  BlockExport(blockExport: BlockExport): void {
+    let params = this.namedReferences(blockExport.exports);
+    params += ` from "${blockExport.fromPath}"`;
+    let atRule = this.postcss.atRule({
+      name: "export",
+      params,
+    });
+    this.root.append(atRule);
+  }
+
+  Rule(rule: Rule<DefinitionAST>): void | boolean {
+    let selectors = new Array<string>();
+    for (let sel of rule.selectors) {
+      let visitor = new SelectorASTBuilder();
+      visit(visitor, sel);
+      selectors.push(visitor.selector);
+    }
+    let currentRule = postcss.rule({selectors});
+    for (let declaration of rule.declarations) {
+      currentRule.append(
+        postcss.decl({prop: declaration.property, value: declaration.value}),
+      );
+    }
+    this.root.append(currentRule);
+    return false;
+  }
+  GlobalDeclaration(globalDeclaration: GlobalDeclaration): false {
+    let selectorBuilder = new SelectorASTBuilder();
+    visit(selectorBuilder, globalDeclaration.selector);
+    let atRule = postcss.atRule({name: BLOCK_GLOBAL, params: selectorBuilder.selector});
+    this.root.append(atRule);
+    return false;
+  }
+}
 
 export class BlockDefinitionCompiler {
   postcss: typeof postcss;
   config: ResolvedConfiguration;
-  constructor(postcssImpl: typeof postcss, config: ResolvedConfiguration) {
+  pathResolver: PathResolver;
+  constructor(postcssImpl: typeof postcss, pathResolver: PathResolver, config: ResolvedConfiguration) {
     this.postcss = postcssImpl;
     this.config = config;
+    this.pathResolver = pathResolver;
   }
 
-  compile(block: Block, root: postcss.Root, _pathResolver: PathResolver): postcss.Root {
-    this.blockReferences(root, block);
-    return root;
+  compile(block: Block, reservedClassNames: Set<string>): postcss.Root {
+    let ast = this.compileToAST(block, reservedClassNames);
+    let visitor = new CompiledDefinitionPostcssASTBuilder(this.postcss);
+    visit(visitor, ast);
+    return visitor.root;
+  }
+
+  globalDeclarations(block: Block): Array<GlobalDeclaration> {
+    let globals = new Array<GlobalDeclaration>();
+    for (let attrValue of block.rootClass.allAttributeValues()) {
+      if (attrValue.isGlobal) {
+        let selector = builders.attributeSelector(attrValue.attribute.name, attrValue.isPresenceRule ? undefined : attrValue.value);
+        globals.push(builders.globalDeclaration(selector));
+      }
+    }
+    return globals;
+  }
+
+  compileToAST(block: Block, reservedClassNames: Set<string>): DefinitionRoot {
+    if (!block.blockAST) {
+      throw new Error("The block's AST is missing.");
+    }
+    let mapper = new CompiledDefinitionMapper(block, this.pathResolver);
+    let definitionRoot: DefinitionRoot = mapToDefinition(mapper, block.blockAST, "block", "definition");
+    definitionRoot.children.unshift(...this.globalDeclarations(block));
+    definitionRoot.children.unshift(builders.blockSyntaxVersion(1));
+    for (let style of block.all(true)) {
+      definitionRoot.children.push(this.styleToRule(style, reservedClassNames));
+    }
+    return definitionRoot;
+  }
+
+  styleToRule(style: Style, reservedClassNames: Set<string>): Rule<DefinitionAST> {
+    let selectors = new Array<Selector<DefinitionAST>>();
+    let blockClass: BlockClass = isAttrValue(style) ? style.blockClass : style;
+    let elementSelector: ClassSelector | ScopeSelector;
+    if (blockClass.isRoot) {
+      elementSelector = builders.scopeSelector();
+    } else {
+      elementSelector = builders.classSelector(blockClass.name);
+    }
+    if (isAttrValue(style)) {
+      let attributeSelector: AttributeSelector;
+      if (style.isPresenceRule) {
+        attributeSelector = builders.attributeSelector(style.attribute.name);
+      } else {
+        attributeSelector = builders.attributeSelector(style.attribute.name, style.value);
+      }
+      selectors.push(builders.keyCompoundSelector(elementSelector, [attributeSelector]));
+    } else {
+      selectors.push(elementSelector);
+    }
+    let declarations = new Array<Declaration>();
+    if (isBlockClass(style) && style.isRoot) {
+      declarations.push(builders.declaration("block-id", `"${style.block.guid}"`));
+      declarations.push(builders.declaration("block-name", `"${style.block.name}"`));
+    }
+    declarations.push(builders.declaration("block-class", style.cssClass(this.config, reservedClassNames)));
+    declarations.push(builders.declaration("block-interface-index", style.index.toString()));
+    let aliasValues = new Array(...style.getStyleAliases());
+    if (aliasValues.length) {
+      declarations.push(builders.declaration("block-alias", aliasValues.join(" ")));
+    }
+    return builders.rule(selectors, declarations);
   }
 
   blockReferences(root: postcss.Root, block: Block): void {
@@ -30,9 +234,12 @@ export class BlockDefinitionCompiler {
     });
   }
 
-  insertReference(_css: postcss.Root, _definitionPath: string) {
-    throw new Error("Method not implemented.");
+  insertReference(css: postcss.Root, definitionPath: string) {
+    let comment = this.postcss.comment({text: `#blockDefinitionURL=${definitionPath}`});
+    Object.assign(comment.raws, {left: "", right: ""});
+    css.append(comment);
   }
+
   insertInlineReference(_css: postcss.Root, _definition: postcss.Root) {
     throw new Error("Method not implemented.");
   }

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
@@ -1,0 +1,26 @@
+import { postcss } from "opticss";
+
+import { Block } from "../BlockTree";
+import { ResolvedConfiguration } from "../configuration";
+
+export const INLINE_DEFINITION_FILE = Symbol("Inline Definition");
+export class BlockDefinitionCompiler {
+  postcss: typeof postcss;
+  config: ResolvedConfiguration;
+  constructor(postcssImpl: typeof postcss, config: ResolvedConfiguration) {
+    this.postcss = postcssImpl;
+    this.config = config;
+  }
+
+  compile(_block: Block): postcss.Root {
+    throw new Error("Method not implemented.");
+    // return postcss.root();
+  }
+
+  insertReference(_css: postcss.Root, _definitionPath: string) {
+    throw new Error("Method not implemented.");
+  }
+  insertInlineReference(_css: postcss.Root, _definition: postcss.Root) {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler.ts
@@ -4,6 +4,13 @@ import { Block } from "../BlockTree";
 import { ResolvedConfiguration } from "../configuration";
 
 export const INLINE_DEFINITION_FILE = Symbol("Inline Definition");
+
+export type PathResolver = (config: ResolvedConfiguration, fromBlock: Block, toBlock: Block, fromPath: string) => string;
+
+export const filesystemPathResolver: PathResolver = (_config: ResolvedConfiguration, _fromBlock: Block, _toBlock: Block, fromPath: string): string => {
+  return fromPath.replace(".block", "");
+};
+
 export class BlockDefinitionCompiler {
   postcss: typeof postcss;
   config: ResolvedConfiguration;
@@ -12,9 +19,15 @@ export class BlockDefinitionCompiler {
     this.config = config;
   }
 
-  compile(_block: Block): postcss.Root {
-    throw new Error("Method not implemented.");
-    // return postcss.root();
+  compile(block: Block, root: postcss.Root, _pathResolver: PathResolver): postcss.Root {
+    this.blockReferences(root, block);
+    return root;
+  }
+
+  blockReferences(root: postcss.Root, block: Block): void {
+    block.eachBlockReference((name, _block) => {
+      root.append(postcss.atRule({name: "block", params: `${name} from ""`}));
+    });
   }
 
   insertReference(_css: postcss.Root, _definitionPath: string) {

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/CompiledDefinitionMapper.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/CompiledDefinitionMapper.ts
@@ -1,0 +1,21 @@
+import { DefinitionAST, Mapper, Name, Rename, builders } from "../../BlockParser/ast";
+import { Block } from "../../BlockTree";
+
+export type PathResolver = (block: Block, fromPath: string) => string;
+
+export class CompiledDefinitionMapper implements Mapper<DefinitionAST> {
+  pathResolver: PathResolver;
+  block: Block;
+  constructor(block: Block, pathResolver: PathResolver) {
+    this.block = block;
+    this.pathResolver = pathResolver;
+  }
+  BlockExport(fromPath: string, exports: Array<Name | Rename>) {
+    fromPath = this.pathResolver(this.block, fromPath);
+    return builders.blockExport(fromPath, exports);
+  }
+  BlockReference(fromPath: string, defaultName: string, references: Array<Name | Rename>) {
+    fromPath = this.pathResolver(this.block, fromPath);
+    return builders.blockReference(fromPath, defaultName, references);
+  }
+}

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/PostcssASTBuilder.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/PostcssASTBuilder.ts
@@ -1,0 +1,103 @@
+import { postcss } from "opticss";
+
+import { BlockExport, BlockReference, BlockSyntaxVersion, DefinitionAST, GlobalDeclaration, LocalBlockExport, Name, Rename, Rule, Visitor, visit } from "../../BlockParser/ast";
+import { BLOCK_GLOBAL } from "../../BlockSyntax";
+
+import { SelectorASTBuilder } from "./SelectorASTBuilder";
+
+export class PostcssASTBuilder implements Visitor<DefinitionAST> {
+  postcss: typeof postcss;
+  root: postcss.Root;
+  currentRule: postcss.Rule | undefined;
+  constructor(postcssImpl: typeof postcss) {
+    this.postcss = postcssImpl;
+    this.root = this.postcss.root();
+  }
+
+  namedReferences(references: Array<Name | Rename>): string {
+    let result = "";
+    result += "(";
+    let prevRef = false;
+    for (let ref of references) {
+      if (prevRef) {
+        result += ", ";
+      }
+      result += ref.name;
+      if (ref.asName) {
+        result += ` as ${ref.asName}`;
+      }
+      prevRef = true;
+    }
+    result += ")";
+    return result;
+  }
+
+  BlockSyntaxVersion(blockSyntaxVersion: BlockSyntaxVersion): void {
+    this.root.append(this.postcss.atRule({
+      name: "block-syntax-version",
+      params: blockSyntaxVersion.version.toString(),
+    }));
+  }
+
+  BlockReference(blockReference: BlockReference): void {
+    let params = "";
+    if (blockReference.defaultName) {
+      params += blockReference.defaultName;
+    }
+    if (blockReference.defaultName && blockReference.references) {
+      params += ", ";
+    }
+    if (blockReference.references) {
+      params += this.namedReferences(blockReference.references);
+    }
+    params += ` from "${blockReference.fromPath}"`;
+    let atRule = this.postcss.atRule({
+      name: "block",
+      params,
+    });
+    this.root.append(atRule);
+  }
+
+  LocalBlockExport(localBlockExport: LocalBlockExport): void {
+    let params = this.namedReferences(localBlockExport.exports);
+    let atRule = this.postcss.atRule({
+      name: "export",
+      params,
+    });
+    this.root.append(atRule);
+  }
+
+  BlockExport(blockExport: BlockExport): void {
+    let params = this.namedReferences(blockExport.exports);
+    params += ` from "${blockExport.fromPath}"`;
+    let atRule = this.postcss.atRule({
+      name: "export",
+      params,
+    });
+    this.root.append(atRule);
+  }
+
+  Rule(rule: Rule<DefinitionAST>): void | boolean {
+    let selectors = new Array<string>();
+    for (let sel of rule.selectors) {
+      let visitor = new SelectorASTBuilder();
+      visit(visitor, sel);
+      selectors.push(visitor.selector);
+    }
+    let currentRule = postcss.rule({selectors});
+    for (let declaration of rule.declarations) {
+      currentRule.append(
+        postcss.decl({prop: declaration.property, value: declaration.value}),
+      );
+    }
+    this.root.append(currentRule);
+    return false;
+  }
+  GlobalDeclaration(globalDeclaration: GlobalDeclaration): false {
+    let selectorBuilder = new SelectorASTBuilder();
+    visit(selectorBuilder, globalDeclaration.selector);
+    let atRule = postcss.atRule({name: BLOCK_GLOBAL, params: selectorBuilder.selector});
+    this.root.append(atRule);
+    return false;
+  }
+}

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/SelectorASTBuilder.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/SelectorASTBuilder.ts
@@ -1,0 +1,31 @@
+
+import { AttributeSelector, ClassSelector, DefinitionAST, ForeignAttributeSelector, ScopeSelector, Visitor } from "../../BlockParser/ast";
+
+export class SelectorASTBuilder implements Visitor<DefinitionAST> {
+  selector: string;
+  constructor() {
+    this.selector = "";
+  }
+  AttributeSelector(attr: AttributeSelector): void {
+    this.selector += `[${attr.attribute}`;
+    if (attr.matches) {
+      this.selector += attr.matches.matcher;
+      this.selector += `"${attr.matches.value}"`;
+    }
+    this.selector += "]";
+  }
+  ForeignAttributeSelector(attr: ForeignAttributeSelector): void {
+    this.selector += `[${attr.ns}|${attr.attribute}`;
+    if (attr.matches) {
+      this.selector += attr.matches.matcher;
+      this.selector += `"${attr.matches.value}"`;
+    }
+    this.selector += "]";
+  }
+  ScopeSelector(_scopeSelector: ScopeSelector): void {
+    this.selector += `:scope`;
+  }
+  ClassSelector(classSelector: ClassSelector): void {
+    this.selector += `.${classSelector.name}`;
+  }
+}

--- a/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/BlockDefinitionCompiler/index.ts
@@ -1,7 +1,7 @@
 import { Dictionary } from "async";
 import { postcss } from "opticss";
 
-import { AttributeSelector, ClassSelector, Declaration, DefinitionAST, DefinitionRoot, GlobalDeclaration, KeyCompoundSelector, Mapper, Name, Rename, Rule, ScopeSelector, Selector, builders, map as mapToDefinition, visit } from "../../BlockParser/ast";
+import { AttributeSelector, ClassSelector, Declaration, DefinitionAST, DefinitionRoot, GlobalDeclaration, KeyCompoundSelector, Rule, ScopeSelector, Selector, builders, map as mapToDefinition, visit } from "../../BlockParser/ast";
 import { AttrValue, Block, BlockClass, Style, isAttrValue, isBlockClass } from "../../BlockTree";
 import { ResolvedConfiguration } from "../../configuration";
 
@@ -134,19 +134,13 @@ export class BlockDefinitionCompiler {
     return rules;
   }
 
-  blockReferences(root: postcss.Root, block: Block): void {
-    block.eachBlockReference((name, _block) => {
-      root.append(postcss.atRule({name: "block", params: `${name} from ""`}));
-    });
-  }
-
-  insertReference(css: postcss.Root, definitionPath: string) {
+  insertBlockDefinitionURLComment(css: postcss.Root, definitionPath: string) {
     let comment = this.postcss.comment({text: `#blockDefinitionURL=${definitionPath}`});
     Object.assign(comment.raws, {left: "", right: ""});
     css.append(comment);
   }
 
-  insertInlineReference(_css: postcss.Root, _definition: postcss.Root) {
+  insertInlineBlockDefinitionURLComment(_css: postcss.Root, _definition: postcss.Root) {
     throw new Error("Method not implemented.");
   }
 }

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -15,7 +15,7 @@ import {
   resolveConfiguration,
 } from "../configuration";
 
-import { BlockDefinitionCompiler, INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
+import { BlockDefinitionCompiler, INLINE_DEFINITION_FILE, PathResolver, filesystemPathResolver } from "./BlockDefinitionCompiler";
 import { ConflictResolver } from "./ConflictResolver";
 
 export { INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
@@ -46,11 +46,11 @@ export class BlockCompiler {
     this.definitionCompiler = new BlockDefinitionCompiler(postcssImpl, this.config);
   }
 
-  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: typeof INLINE_DEFINITION_FILE): CompiledBlockAndInlineDefinition;
-  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string): CompiledBlockAndDefinition;
-  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string | typeof INLINE_DEFINITION_FILE): CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition {
+  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: typeof INLINE_DEFINITION_FILE, pathResolver: PathResolver): CompiledBlockAndInlineDefinition;
+  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string, pathResolver: PathResolver): CompiledBlockAndDefinition;
+  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string | typeof INLINE_DEFINITION_FILE, pathResolver: PathResolver = filesystemPathResolver): CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition {
     let css = this.compile(block, root, reservedClassNames);
-    let definition = this.definitionCompiler.compile(block);
+    let definition = this.definitionCompiler.compile(block, root, pathResolver);
     let result: CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition;
 
     if (definitionPath === INLINE_DEFINITION_FILE) {

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -49,6 +49,14 @@ export class BlockCompiler {
     this.definitionCompiler = definitionCompiler;
   }
 
+  /**
+   * Compiles the block and also produces a corresponding block definition file.
+   *
+   * Note: the definition file is not actually written to any path; it is the
+   * responsibility of the caller to write the files to locations that allow
+   * definition file to be found at the path specified.
+   * @param definitionPath A relative path to the definition file from the block file. Pass the symbol INLINE_DEFINITION_FILE if you want the definition file to be inserted into the definition file.
+   */
   compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: typeof INLINE_DEFINITION_FILE): CompiledBlockAndInlineDefinition;
   compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string): CompiledBlockAndDefinition;
   compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string | typeof INLINE_DEFINITION_FILE): CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition {
@@ -60,13 +68,13 @@ export class BlockCompiler {
     let result: CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition;
 
     if (definitionPath === INLINE_DEFINITION_FILE) {
-      this.definitionCompiler.insertInlineReference(css, definition);
+      this.definitionCompiler.insertInlineBlockDefinitionURLComment(css, definition);
       result = {
         definitionPath,
         css,
       };
     } else {
-      this.definitionCompiler.insertReference(css, definitionPath);
+      this.definitionCompiler.insertBlockDefinitionURLComment(css, definitionPath);
       result = {
         definitionPath,
         css,
@@ -85,6 +93,10 @@ export class BlockCompiler {
     return result;
   }
 
+  /**
+   * Compile the block to a postcss AST by walking the postcss AST from parsing
+   * and removing/replacing the css blocks' specific syntax with standard CSS.
+   */
   compile(block: Block, root: postcss.Root, reservedClassNames: Set<string>): postcss.Root {
     let resolver = new ConflictResolver(this.config, reservedClassNames);
     let filename = this.config.importer.debugIdentifier(block.identifier, this.config);

--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -15,7 +15,22 @@ import {
   resolveConfiguration,
 } from "../configuration";
 
+import { BlockDefinitionCompiler, INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
 import { ConflictResolver } from "./ConflictResolver";
+
+export { INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
+
+export interface CompiledBlockAndDefinition {
+  definitionPath: string;
+  css: postcss.Root;
+  definition: postcss.Root;
+}
+
+export interface CompiledBlockAndInlineDefinition {
+  definitionPath: typeof INLINE_DEFINITION_FILE;
+  css: postcss.Root;
+}
+
 /**
  * Compiler that, given a Block will return a transformed AST
  * interface is `BlockParser.parse`.
@@ -23,10 +38,45 @@ import { ConflictResolver } from "./ConflictResolver";
 export class BlockCompiler {
   private config: ResolvedConfiguration;
   private postcss: typeof postcss;
+  private definitionCompiler: BlockDefinitionCompiler;
 
   constructor(postcssImpl: typeof postcss, opts?: Options) {
     this.config = resolveConfiguration(opts);
     this.postcss = postcssImpl;
+    this.definitionCompiler = new BlockDefinitionCompiler(postcssImpl, this.config);
+  }
+
+  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: typeof INLINE_DEFINITION_FILE): CompiledBlockAndInlineDefinition;
+  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string): CompiledBlockAndDefinition;
+  compileWithDefinition(block: Block, root: postcss.Root, reservedClassNames: Set<string>, definitionPath: string | typeof INLINE_DEFINITION_FILE): CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition {
+    let css = this.compile(block, root, reservedClassNames);
+    let definition = this.definitionCompiler.compile(block);
+    let result: CompiledBlockAndDefinition | CompiledBlockAndInlineDefinition;
+
+    if (definitionPath === INLINE_DEFINITION_FILE) {
+      this.definitionCompiler.insertInlineReference(css, definition);
+      result = {
+        definitionPath,
+        css,
+      };
+    } else {
+      this.definitionCompiler.insertReference(css, definitionPath);
+      result = {
+        definitionPath,
+        css,
+        definition,
+      };
+    }
+
+    let startComment = postcss.comment({text: `#css-blocks ${block.guid}`});
+    startComment.raws.after = "\n";
+    css.prepend(startComment);
+
+    let endComment = postcss.comment({text: `#css-blocks end`});
+    endComment.raws.after = "\n";
+    css.append(endComment);
+
+    return result;
   }
 
   compile(block: Block, root: postcss.Root, reservedClassNames: Set<string>): postcss.Root {

--- a/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/BlockParser.ts
@@ -8,6 +8,7 @@ import { FileIdentifier } from "../importing";
 
 import { addInterfaceIndexes } from "./features/add-interface-indexes";
 import { addPresetSelectors } from "./features/add-preset-selectors";
+import { builders } from "./ast";
 import { assertForeignGlobalAttribute } from "./features/assert-foreign-global-attribute";
 import { composeBlock } from "./features/composes-block";
 import { constructBlock } from "./features/construct-block";
@@ -102,6 +103,7 @@ export class BlockParser {
 
     // Create our new Block object and save reference to the raw AST.
     let block = new Block(name, identifier, guid, root);
+    block.blockAST = builders.root();
 
     // Add any errors that surfaced during name and GUID discovery.
     if (nameDiscoveryError) {

--- a/packages/@css-blocks/core/src/BlockParser/ast.ts
+++ b/packages/@css-blocks/core/src/BlockParser/ast.ts
@@ -1,0 +1,176 @@
+import { assertNever } from "@opticss/util";
+
+export type TopLevelNode = BlockReference | LocalBlockExport | BlockExport;
+export type Node = Root | TopLevelNode;
+
+export type TopLevelDefinitionNode = BlockReference | LocalBlockExport | BlockExport;
+export type DefinitionNode = DefinitionRoot | TopLevelDefinitionNode;
+
+const NODE_TYPES = new Set<Node["type"]>();
+const DEFINITION_NODE_TYPES = new Set<DefinitionNode["type"]>();
+
+export interface Name {
+  name: string;
+  asName?: undefined;
+}
+
+export interface Rename {
+  name: string;
+  asName: string;
+}
+
+export interface Root {
+  type: "Root";
+  children: Array<TopLevelNode>;
+}
+NODE_TYPES.add("Root");
+
+export interface DefinitionRoot {
+  type: "DefinitionRoot";
+  children: Array<TopLevelDefinitionNode>;
+}
+DEFINITION_NODE_TYPES.add("DefinitionRoot");
+
+export interface BlockReference {
+  type: "BlockReference";
+  references?: Array<Name | Rename>;
+  defaultName?: string;
+  fromPath: string;
+}
+NODE_TYPES.add("BlockReference");
+DEFINITION_NODE_TYPES.add("BlockReference");
+
+/* The statement that exports a block that was previously imported via `@block` */
+export interface LocalBlockExport {
+  type: "LocalBlockExport";
+  exports: Array<Name | Rename>;
+}
+NODE_TYPES.add("LocalBlockExport");
+DEFINITION_NODE_TYPES.add("LocalBlockExport");
+
+/* The statement that exports a block that was previously imported via `@block` */
+export interface BlockExport {
+  type: "BlockExport";
+  exports: Array<Name | Rename>;
+  fromPath: string;
+}
+NODE_TYPES.add("BlockExport");
+DEFINITION_NODE_TYPES.add("BlockExport");
+
+export namespace typeguards {
+  export function isNode(node: unknown): node is Node {
+    return typeof node === "object"
+           && node !== null
+           && typeof (<Node>node).type === "string"
+           && NODE_TYPES.has((<Node>node).type);
+  }
+  export function isDefinitionNode(node: unknown): node is DefinitionNode {
+    return typeof node === "object"
+           && node !== null
+           && typeof (<Node>node).type === "string"
+           && DEFINITION_NODE_TYPES.has((<DefinitionNode>node).type);
+  }
+  export function isRoot(node: unknown): node is Root {
+    return typeguards.isNode(node) && node.type === "Root";
+  }
+  export function isDefinitionRoot(node: unknown): node is DefinitionRoot {
+    return typeguards.isDefinitionNode(node) && node.type === "DefinitionRoot";
+  }
+  export function isBlockReference(node: unknown): node is BlockReference {
+    return typeguards.isNode(node) && node.type === "BlockReference";
+  }
+  export function isBlockExport(node: unknown): node is BlockExport {
+    return typeguards.isNode(node) && node.type === "BlockExport";
+  }
+  export function isLocalBlockExport(node: unknown): node is LocalBlockExport {
+    return typeguards.isNode(node) && node.type === "LocalBlockExport";
+  }
+}
+
+export namespace builders {
+  export function root(): Root {
+    return {
+      type: "Root",
+      children: [],
+    };
+  }
+
+  export function definitionRoot(): DefinitionRoot {
+    return {
+      type: "DefinitionRoot",
+      children: [],
+    };
+  }
+
+  export function blockReference(fromPath: string, defaultName: string | undefined, references: Array<Name | Rename> | undefined): BlockReference {
+    return {
+      type: "BlockReference",
+      fromPath,
+      defaultName,
+      references,
+    };
+  }
+
+  export function localBlockExport(exports: Array<Name | Rename>): LocalBlockExport {
+    return {
+      type: "LocalBlockExport",
+      exports,
+    };
+  }
+
+  export function blockExport(fromPath: string, exports: Array<Name | Rename>): BlockExport {
+    return {
+      type: "BlockExport",
+      fromPath,
+      exports,
+    };
+  }
+}
+
+export interface Visitor {
+  Root?(root: Root): void;
+  BlockReference?(blockReference: BlockReference): void;
+  LocalBlockExport?(localBlockExport: LocalBlockExport): void;
+  BlockExport?(blockExport: BlockExport): void;
+}
+
+export interface DefinitionVisitor {
+  DefinitionRoot?(root: DefinitionRoot): void;
+  BlockReference?(blockReference: BlockReference): void;
+  LocalBlockExport?(localBlockExport: LocalBlockExport): void;
+  BlockExport?(blockExport: BlockExport): void;
+}
+
+export function visit(visitor: Visitor, node: Node) {
+  if (typeguards.isRoot(node)) {
+    if (visitor.Root) visitor.Root(node);
+    for (let child of node.children) {
+      visit(visitor, child);
+    }
+  } else if (typeguards.isBlockReference(node)) {
+    if (visitor.BlockReference) visitor.BlockReference(node);
+  } else if (typeguards.isBlockExport(node)) {
+    if (visitor.BlockExport) visitor.BlockExport(node);
+  } else if (typeguards.isLocalBlockExport(node)) {
+    if (visitor.LocalBlockExport) visitor.LocalBlockExport(node);
+  } else {
+    assertNever(node);
+  }
+}
+
+export function visitDefinition(visitor: DefinitionVisitor, node: DefinitionNode) {
+  if (typeguards.isDefinitionRoot(node)) {
+    if (visitor.DefinitionRoot) visitor.DefinitionRoot(node);
+    for (let child of node.children) {
+      visit(visitor, child);
+    }
+  } else if (typeguards.isBlockReference(node)) {
+    if (visitor.BlockReference) visitor.BlockReference(node);
+  } else if (typeguards.isBlockExport(node)) {
+    if (visitor.BlockExport) visitor.BlockExport(node);
+  } else if (typeguards.isLocalBlockExport(node)) {
+    if (visitor.LocalBlockExport) visitor.LocalBlockExport(node);
+  } else {
+    assertNever(node);
+  }
+}

--- a/packages/@css-blocks/core/src/BlockParser/ast.ts
+++ b/packages/@css-blocks/core/src/BlockParser/ast.ts
@@ -1,13 +1,22 @@
 import { assertNever } from "@opticss/util";
+export type AnySelector<isDefinition extends DefinitionAST | BlockAST> =
+  ComplexSelector<isDefinition>
+  | ContextCompoundSelector<isDefinition>
+  | KeyCompoundSelector<isDefinition>
+  | ScopeSelector
+  | ClassSelector
+  | AttributeSelector
+  | ForeignAttributeSelector
+  | PseudoClassSelector
+  | PseudoElementSelector;
+export type TopLevelNode<isDefinition extends DefinitionAST | BlockAST> = BlockSyntaxVersion | BlockReference | LocalBlockExport | BlockExport | Rule<isDefinition> | GlobalDeclaration;
+export type Node<isDefinition extends DefinitionAST | BlockAST> =
+  Root<isDefinition>
+  | TopLevelNode<isDefinition>
+  | AnySelector<isDefinition>
+  | Declaration;
 
-export type TopLevelNode = BlockReference | LocalBlockExport | BlockExport;
-export type Node = Root | TopLevelNode;
-
-export type TopLevelDefinitionNode = BlockReference | LocalBlockExport | BlockExport;
-export type DefinitionNode = DefinitionRoot | TopLevelDefinitionNode;
-
-const NODE_TYPES = new Set<Node["type"]>();
-const DEFINITION_NODE_TYPES = new Set<DefinitionNode["type"]>();
+const NODE_TYPES = new Set<Node<BlockAST>["type"]>();
 
 export interface Name {
   name: string;
@@ -19,17 +28,21 @@ export interface Rename {
   asName: string;
 }
 
-export interface Root {
+export interface Root<isDefinition extends DefinitionAST | BlockAST = BlockAST> {
   type: "Root";
-  children: Array<TopLevelNode>;
+  children: Array<TopLevelNode<isDefinition>>;
 }
 NODE_TYPES.add("Root");
 
-export interface DefinitionRoot {
-  type: "DefinitionRoot";
-  children: Array<TopLevelDefinitionNode>;
+export type DefinitionAST = "definition";
+export type BlockAST = "block";
+export type DefinitionRoot = Root<DefinitionAST>;
+
+export interface BlockSyntaxVersion {
+  type: "BlockSyntaxVersion";
+  version: number;
 }
-DEFINITION_NODE_TYPES.add("DefinitionRoot");
+NODE_TYPES.add("BlockSyntaxVersion");
 
 export interface BlockReference {
   type: "BlockReference";
@@ -38,7 +51,6 @@ export interface BlockReference {
   fromPath: string;
 }
 NODE_TYPES.add("BlockReference");
-DEFINITION_NODE_TYPES.add("BlockReference");
 
 /* The statement that exports a block that was previously imported via `@block` */
 export interface LocalBlockExport {
@@ -46,7 +58,6 @@ export interface LocalBlockExport {
   exports: Array<Name | Rename>;
 }
 NODE_TYPES.add("LocalBlockExport");
-DEFINITION_NODE_TYPES.add("LocalBlockExport");
 
 /* The statement that exports a block that was previously imported via `@block` */
 export interface BlockExport {
@@ -55,26 +66,125 @@ export interface BlockExport {
   fromPath: string;
 }
 NODE_TYPES.add("BlockExport");
-DEFINITION_NODE_TYPES.add("BlockExport");
+
+export type KeyCompoundSelector<isDefinition extends DefinitionAST | BlockAST> = CompoundSelector<isDefinition, AttributeSelector, PseudoClassSelector, PseudoElementSelector>;
+export type ContextCompoundSelector<isDefinition extends DefinitionAST | BlockAST> = CompoundSelector<isDefinition, ForeignAttributeSelector | AttributeSelector, PseudoClassSelector, never>;
+export type ElementSelector = ScopeSelector | ClassSelector;
+export type Selector<isDefinition extends DefinitionAST | BlockAST> = ElementSelector | KeyCompoundSelector<isDefinition> | ComplexSelector<isDefinition>;
+
+export interface PseudoElementSelector {
+  type: "PseudoElementSelector";
+  /** The name of the psuedoelement without the `::` at the beginning. */
+  name: string;
+}
+NODE_TYPES.add("PseudoElementSelector");
+
+export interface PseudoClassSelector {
+  type: "PseudoClassSelector";
+  /** The name of the psuedoclass without the `:` at the beginning. */
+  name: string;
+}
+NODE_TYPES.add("PseudoClassSelector");
+
+export interface SelectorAndCombinator<isDefinition extends DefinitionAST | BlockAST> {
+  selector: ContextCompoundSelector<isDefinition>;
+  combinator: " " | ">" | "+" | "~";
+}
+
+export interface ComplexSelector<isDefinition extends DefinitionAST | BlockAST> {
+  type: "ComplexSelector";
+  /** There should be at least one context selector. */
+  contextSelectors: Array<SelectorAndCombinator<isDefinition>>;
+  keySelector: KeyCompoundSelector<isDefinition>;
+}
+NODE_TYPES.add("ComplexSelector");
+
+export interface CompoundSelector<
+  isDefinition extends DefinitionAST | BlockAST,
+  AttributeSelectorType extends ForeignAttributeSelector | AttributeSelector,
+  PseudoClassType extends PseudoClassSelector | never,
+  PseudoElementType extends PseudoElementSelector | never,
+> {
+  type: "CompoundSelector";
+  element: ElementSelector;
+  attributes?: Array<AttributeSelectorType>;
+  elementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : (PseudoClassType extends never ? undefined : Array<PseudoClassType>);
+  pseudoElement?: PseudoElementType;
+  pseudoElementPseudoClasses?: isDefinition extends DefinitionAST
+                               ? undefined
+                               : (PseudoElementSelector extends never
+                                  ? undefined
+                                  : (PseudoClassType extends never ? undefined : Array<PseudoClassType>));
+}
+NODE_TYPES.add("CompoundSelector");
+
+export interface ForeignAttributeSelector {
+  type: "ForeignAttributeSelector";
+  ns: string;
+  attribute: string;
+  matches?: {
+    matcher: "=";
+    value: string;
+  };
+}
+NODE_TYPES.add("ForeignAttributeSelector");
+
+export interface AttributeSelector {
+  type: "AttributeSelector";
+  ns?: undefined;
+  attribute: string;
+  matches?: {
+    matcher: "=";
+    value: string;
+  };
+}
+NODE_TYPES.add("AttributeSelector");
+
+export interface ScopeSelector {
+  type: "ScopeSelector";
+  value: ":scope";
+}
+NODE_TYPES.add("ScopeSelector");
+
+export interface ClassSelector {
+  type: "ClassSelector";
+  /** The name of the class without the `.` at the beginning. */
+  name: string;
+}
+NODE_TYPES.add("ClassSelector");
+
+export interface Declaration {
+  type: "Declaration";
+  property: string;
+  value: string;
+}
+NODE_TYPES.add("Declaration");
+
+export interface Rule<isDefinition extends DefinitionAST | BlockAST> {
+  type: "Rule";
+  selectors: Array<Selector<isDefinition>>;
+  declarations: Array<Declaration>;
+}
+NODE_TYPES.add("Rule");
+
+export interface GlobalDeclaration {
+  type: "GlobalDeclaration";
+  selector: AttributeSelector;
+}
+NODE_TYPES.add("GlobalDeclaration");
 
 export namespace typeguards {
-  export function isNode(node: unknown): node is Node {
+  export function isNode<isDefinition extends DefinitionAST | BlockAST>(node: unknown): node is Node<isDefinition> {
     return typeof node === "object"
            && node !== null
-           && typeof (<Node>node).type === "string"
-           && NODE_TYPES.has((<Node>node).type);
+           && typeof (<Node<isDefinition>>node).type === "string"
+           && NODE_TYPES.has((<Node<isDefinition>>node).type);
   }
-  export function isDefinitionNode(node: unknown): node is DefinitionNode {
-    return typeof node === "object"
-           && node !== null
-           && typeof (<Node>node).type === "string"
-           && DEFINITION_NODE_TYPES.has((<DefinitionNode>node).type);
-  }
-  export function isRoot(node: unknown): node is Root {
+  export function isRoot<isDefinition extends DefinitionAST | BlockAST>(node: unknown): node is Root<isDefinition> {
     return typeguards.isNode(node) && node.type === "Root";
   }
-  export function isDefinitionRoot(node: unknown): node is DefinitionRoot {
-    return typeguards.isDefinitionNode(node) && node.type === "DefinitionRoot";
+  export function isBlockSyntaxVersion(node: unknown): node is BlockSyntaxVersion {
+    return typeguards.isNode(node) && node.type === "BlockSyntaxVersion";
   }
   export function isBlockReference(node: unknown): node is BlockReference {
     return typeguards.isNode(node) && node.type === "BlockReference";
@@ -85,20 +195,53 @@ export namespace typeguards {
   export function isLocalBlockExport(node: unknown): node is LocalBlockExport {
     return typeguards.isNode(node) && node.type === "LocalBlockExport";
   }
+  export function isPseudoElementSelector(node: unknown): node is PseudoElementSelector {
+    return typeguards.isNode(node) && node.type === "PseudoElementSelector";
+  }
+  export function isPseudoClassSelector(node: unknown): node is PseudoClassSelector {
+    return typeguards.isNode(node) && node.type === "PseudoClassSelector";
+  }
+  export function isComplexSelector<isDefinition extends DefinitionAST | BlockAST>(node: unknown): node is ComplexSelector<isDefinition> {
+    return typeguards.isNode(node) && node.type === "ComplexSelector";
+  }
+  export function isCompoundSelector<isDefinition extends DefinitionAST | BlockAST>(node: unknown): node is KeyCompoundSelector<isDefinition> | ContextCompoundSelector<isDefinition> {
+    return typeguards.isNode(node) && node.type === "CompoundSelector";
+  }
+  export function isAttributeSelector(node: unknown): node is AttributeSelector {
+    return typeguards.isNode(node) && node.type === "AttributeSelector";
+  }
+  export function isForeignAttributeSelector(node: unknown): node is ForeignAttributeSelector {
+    return typeguards.isNode(node) && node.type === "ForeignAttributeSelector";
+  }
+  export function isScopeSelector(node: unknown): node is ScopeSelector {
+    return typeguards.isNode(node) && node.type === "ScopeSelector";
+  }
+  export function isClassSelector(node: unknown): node is ClassSelector {
+    return typeguards.isNode(node) && node.type === "ClassSelector";
+  }
+  export function isDeclaration(node: unknown): node is Declaration {
+    return typeguards.isNode(node) && node.type === "Declaration";
+  }
+  export function isRule<isDefinition extends DefinitionAST | BlockAST>(node: unknown): node is Rule<isDefinition> {
+    return typeguards.isNode(node) && node.type === "Rule";
+  }
+  export function isGlobalDeclaration(node: unknown): node is GlobalDeclaration {
+    return typeguards.isNode(node) && node.type === "GlobalDeclaration";
+  }
 }
 
 export namespace builders {
-  export function root(): Root {
+  export function root<isDefinition extends DefinitionAST | BlockAST>(children: Array<TopLevelNode<isDefinition>> = []): Root<isDefinition> {
     return {
       type: "Root",
-      children: [],
+      children,
     };
   }
 
-  export function definitionRoot(): DefinitionRoot {
+  export function blockSyntaxVersion(version: number): BlockSyntaxVersion {
     return {
-      type: "DefinitionRoot",
-      children: [],
+      type: "BlockSyntaxVersion",
+      version,
     };
   }
 
@@ -125,51 +268,533 @@ export namespace builders {
       exports,
     };
   }
-}
 
-export interface Visitor {
-  Root?(root: Root): void;
-  BlockReference?(blockReference: BlockReference): void;
-  LocalBlockExport?(localBlockExport: LocalBlockExport): void;
-  BlockExport?(blockExport: BlockExport): void;
-}
-
-export interface DefinitionVisitor {
-  DefinitionRoot?(root: DefinitionRoot): void;
-  BlockReference?(blockReference: BlockReference): void;
-  LocalBlockExport?(localBlockExport: LocalBlockExport): void;
-  BlockExport?(blockExport: BlockExport): void;
-}
-
-export function visit(visitor: Visitor, node: Node) {
-  if (typeguards.isRoot(node)) {
-    if (visitor.Root) visitor.Root(node);
-    for (let child of node.children) {
-      visit(visitor, child);
+  export function pseudoElementSelector(name: string): PseudoElementSelector {
+    return {
+      type: "PseudoElementSelector",
+      name,
+    };
+  }
+  export function pseudoClassSelector(name: string): PseudoClassSelector {
+    return {
+      type: "PseudoClassSelector",
+      name,
+    };
+  }
+  export function complexSelector<isDefinition extends DefinitionAST | BlockAST>(contextSelectors: Array<SelectorAndCombinator<isDefinition>>, keySelector: KeyCompoundSelector<isDefinition>): ComplexSelector<isDefinition> {
+    if (contextSelectors.length === 0) {
+      throw new Error("At least one context selector is required to build a complex selector.");
     }
-  } else if (typeguards.isBlockReference(node)) {
-    if (visitor.BlockReference) visitor.BlockReference(node);
-  } else if (typeguards.isBlockExport(node)) {
-    if (visitor.BlockExport) visitor.BlockExport(node);
-  } else if (typeguards.isLocalBlockExport(node)) {
-    if (visitor.LocalBlockExport) visitor.LocalBlockExport(node);
-  } else {
-    assertNever(node);
+    return {
+      type: "ComplexSelector",
+      keySelector,
+      contextSelectors,
+    };
+  }
+  export function compoundSelector<isDefinition extends DefinitionAST | BlockAST>(
+    element: ElementSelector,
+    attributes?: Array<ForeignAttributeSelector | AttributeSelector>,
+    elementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : Array<PseudoClassSelector>,
+    pseudoElement?: PseudoElementSelector,
+    pseudoElementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : Array<PseudoClassSelector>,
+  ): CompoundSelector<isDefinition, AttributeSelector | ForeignAttributeSelector, PseudoClassSelector, PseudoElementSelector> {
+    return {
+      type: "CompoundSelector",
+      element,
+      attributes,
+      elementPseudoClasses,
+      pseudoElement,
+      pseudoElementPseudoClasses,
+    };
+  }
+  export function keyCompoundSelector<isDefinition extends DefinitionAST | BlockAST>(
+    element: ElementSelector,
+    attributes?: Array<AttributeSelector>,
+    elementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : Array<PseudoClassSelector>,
+    pseudoElement?: PseudoElementSelector,
+    pseudoElementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : Array<PseudoClassSelector>,
+  ): KeyCompoundSelector<isDefinition> {
+    return {
+      type: "CompoundSelector",
+      element,
+      attributes,
+      elementPseudoClasses,
+      pseudoElement,
+      pseudoElementPseudoClasses,
+    };
+  }
+  export function contextCompoundSelector<isDefinition extends DefinitionAST | BlockAST>(
+    element: ElementSelector,
+    attributes?: Array<ForeignAttributeSelector | AttributeSelector>,
+    elementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : Array<PseudoClassSelector>,
+    pseudoElementPseudoClasses?: isDefinition extends DefinitionAST ? undefined : Array<PseudoClassSelector>,
+  ): ContextCompoundSelector<isDefinition> {
+    return {
+      type: "CompoundSelector",
+      element,
+      attributes,
+      elementPseudoClasses,
+      pseudoElementPseudoClasses,
+    };
+  }
+  export function attributeSelector(attribute: string, value?: string): AttributeSelector {
+    let attrSelector: AttributeSelector = {
+      type: "AttributeSelector",
+      attribute,
+    };
+    if (value) {
+      attrSelector.matches = { matcher: "=", value };
+    }
+    return attrSelector;
+  }
+  export function foreignAttributeSelector(ns: string, attribute: string, value?: string): ForeignAttributeSelector {
+    let attrSelector: ForeignAttributeSelector = {
+      type: "ForeignAttributeSelector",
+      ns,
+      attribute,
+    };
+    if (value) {
+      attrSelector.matches = { matcher: "=", value };
+    }
+    return attrSelector;
+  }
+  export function scopeSelector(): ScopeSelector {
+    return {
+      type: "ScopeSelector",
+      value: ":scope",
+    };
+  }
+  export function classSelector(name: string): ClassSelector {
+    return {
+      type: "ClassSelector",
+      name,
+    };
+  }
+  export function declaration(property: string, value: string): Declaration {
+    return {
+      type: "Declaration",
+      property,
+      value,
+    };
+  }
+  export function rule<isDefinition extends DefinitionAST | BlockAST>(selectors: Array<Selector<isDefinition>>, declarations: Array<Declaration>): Rule<isDefinition> {
+    return {
+      type: "Rule",
+      selectors,
+      declarations,
+    };
+  }
+  export function globalDeclaration(selector: AttributeSelector): GlobalDeclaration {
+    return {
+      type: "GlobalDeclaration",
+      selector,
+    };
   }
 }
 
-export function visitDefinition(visitor: DefinitionVisitor, node: DefinitionNode) {
-  if (typeguards.isDefinitionRoot(node)) {
-    if (visitor.DefinitionRoot) visitor.DefinitionRoot(node);
+export interface Visitor<isDefinition extends DefinitionAST | BlockAST> {
+  Root?(root: Root<isDefinition>): void | boolean | undefined;
+  BlockSyntaxVersion?(blockSyntaxVersion: BlockSyntaxVersion): void | boolean | undefined;
+  BlockReference?(blockReference: BlockReference): void | boolean | undefined;
+  LocalBlockExport?(localBlockExport: LocalBlockExport): void | boolean | undefined;
+  BlockExport?(blockExport: BlockExport): void | boolean | undefined;
+  PseudoElementSelector?(pseudoElementSelector: PseudoElementSelector): void | boolean | undefined;
+  PseudoClassSelector?(pseudoClassSelector: PseudoClassSelector): void | boolean | undefined;
+  ComplexSelector?(complexSelector: ComplexSelector<isDefinition>): void | boolean | undefined;
+  CompoundSelector?(compoundSelector: KeyCompoundSelector<isDefinition> | ContextCompoundSelector<isDefinition>): void | boolean | undefined;
+  AttributeSelector?(attributeSelector: AttributeSelector): void | boolean | undefined;
+  ForeignAttributeSelector?(foreignAttributeSelector: ForeignAttributeSelector): void | boolean | undefined;
+  ScopeSelector?(scopeSelector: ScopeSelector): void | boolean | undefined;
+  ClassSelector?(classSelector: ClassSelector): void | boolean | undefined;
+  Declaration?(declaration: Declaration): void | boolean | undefined;
+  Rule?(rule: Rule<isDefinition>): void | boolean | undefined;
+  GlobalDeclaration?(globalDeclaration: GlobalDeclaration): void | boolean | undefined;
+}
+
+export interface Mapper<
+  isToDefinition extends DefinitionAST | BlockAST
+> {
+  Root?(children: Array<TopLevelNode<isToDefinition>>): Root<isToDefinition>;
+  BlockSyntaxVersion?(version: number): BlockSyntaxVersion;
+  BlockReference?(fromPath: string, defaultName: string | undefined, references: Array<Name | Rename> | undefined): BlockReference;
+  LocalBlockExport?(exports: Array<Name | Rename>): LocalBlockExport;
+  BlockExport?(fromPath: string, exports: Array<Name | Rename>): BlockExport;
+  PseudoElementSelector?(name: string): PseudoElementSelector;
+  PseudoClassSelector?(name: string): PseudoClassSelector;
+  ComplexSelector?(contextSelectors: Array<SelectorAndCombinator<isToDefinition>>, keySelector: KeyCompoundSelector<isToDefinition>): ComplexSelector<isToDefinition>;
+  CompoundSelector?(
+    element: ElementSelector,
+    attributes?: Array<AttributeSelector | ForeignAttributeSelector>,
+    elementPseudoClasses?: Array<PseudoClassSelector>,
+    pseudoElement?: PseudoElementSelector,
+    pseudoElementPseudoClasses?: Array<PseudoClassSelector>,
+  ): KeyCompoundSelector<isToDefinition> | ContextCompoundSelector<isToDefinition>;
+  AttributeSelector?(attribute: string, value?: string): AttributeSelector;
+  ForeignAttributeSelector?(ns: string, attribute: string, value?: string): ForeignAttributeSelector;
+  ScopeSelector?(): ScopeSelector;
+  ClassSelector?(name: string): ClassSelector;
+  Declaration?(property: string, value: string): Declaration;
+  Rule?(selectors: Array<Selector<isToDefinition>>, declarations: Array<Declaration>): Rule<isToDefinition>;
+  GlobalDeclaration?(selector: AttributeSelector): GlobalDeclaration;
+}
+
+export function map<
+  isFromDefinition extends DefinitionAST | BlockAST,
+  isToDefinition extends DefinitionAST | BlockAST,
+  N extends Node<isFromDefinition>,
+>(mapper: Mapper<isToDefinition>, node: N, fromType: isFromDefinition, toType: isToDefinition,
+): N extends Root<isFromDefinition> ? Root<isToDefinition> :
+                                            (N extends Rule<isFromDefinition> ? Rule<isToDefinition> :
+                                             (N extends ComplexSelector<isFromDefinition> ? ComplexSelector<isToDefinition> :
+                                              (N extends ContextCompoundSelector<isFromDefinition> ? ContextCompoundSelector<isToDefinition> :
+                                               (N extends KeyCompoundSelector<isFromDefinition> ? KeyCompoundSelector<isToDefinition> : N)))) {
+  if (typeguards.isRoot<isFromDefinition>(node)) {
+    let children: Array<TopLevelNode<isToDefinition>> = [];
+    for (let child of node.children) {
+      let c: TopLevelNode<isToDefinition> = map(mapper, child, fromType, toType);
+      children.push(c);
+    }
+    let ret: Root<isToDefinition>;
+    if (mapper.Root) {
+      ret = mapper.Root(children);
+    } else {
+      ret = builders.root(children);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isBlockSyntaxVersion(node)) {
+    let ret: BlockSyntaxVersion;
+    if (mapper.BlockSyntaxVersion) {
+      ret = mapper.BlockSyntaxVersion(node.version);
+    } else {
+      ret = builders.blockSyntaxVersion(node.version);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isBlockReference(node)) {
+    let references: BlockReference["references"] | undefined;
+    if (node.references) {
+      references = [];
+      for (let ref of node.references) {
+        references.push(Object.assign({}, ref));
+      }
+    }
+    let ret: BlockReference;
+    if (mapper.BlockReference) {
+      ret = mapper.BlockReference(node.fromPath, node.defaultName, references);
+    } else {
+      ret = builders.blockReference(node.fromPath, node.defaultName, references);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isBlockExport(node)) {
+    let exports: BlockExport["exports"] = [];
+    for (let e of node.exports) {
+      exports.push(Object.assign({}, e));
+    }
+    let ret: BlockExport;
+    if (mapper.BlockExport) {
+      ret = mapper.BlockExport(node.fromPath, exports);
+    } else {
+      ret = builders.blockExport(node.fromPath, exports);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isLocalBlockExport(node)) {
+    let exports: LocalBlockExport["exports"] = [];
+    for (let e of node.exports) {
+      exports.push(Object.assign({}, e));
+    }
+    let ret: LocalBlockExport;
+    if (mapper.LocalBlockExport) {
+      ret = mapper.LocalBlockExport(exports);
+    } else {
+      ret = builders.localBlockExport(exports);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isComplexSelector<isFromDefinition>(node)) {
+    let contextSelectors: ComplexSelector<isToDefinition>["contextSelectors"] = [];
+    for (let ctx of node.contextSelectors) {
+      contextSelectors.push({selector: map(mapper, ctx.selector, fromType, toType), combinator: ctx.combinator});
+    }
+    let keySelector = map(mapper, node.keySelector, fromType, toType);
+    let ret: ComplexSelector<isToDefinition>;
+    if (mapper.ComplexSelector) {
+      ret = mapper.ComplexSelector(contextSelectors, keySelector);
+    } else {
+      ret = builders.complexSelector(contextSelectors, keySelector);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isForeignAttributeSelector(node)) {
+    let {ns, attribute, matches} = node;
+    let value = matches ? matches.value : undefined;
+    let ret: ForeignAttributeSelector;
+    if (mapper.ForeignAttributeSelector) {
+      ret = mapper.ForeignAttributeSelector(ns, attribute, value);
+    } else {
+      ret = builders.foreignAttributeSelector(ns, attribute, value);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isAttributeSelector(node)) {
+    let {attribute, matches} = node;
+    let value = matches ? matches.value : undefined;
+    let ret: AttributeSelector;
+    if (mapper.AttributeSelector) {
+      ret = mapper.AttributeSelector(attribute, value);
+    } else {
+      ret = builders.attributeSelector(attribute, value);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isCompoundSelector<isFromDefinition>(node)) {
+    let element = map(mapper, node.element, fromType, toType);
+    let attributes: Array<ForeignAttributeSelector | AttributeSelector> | undefined;
+    // []
+    if (node.attributes) {
+      attributes = [];
+      for (let attr of node.attributes) { attributes.push(map(mapper, attr, fromType, toType)); }
+    }
+    let elementPseudoClasses: Array<PseudoClassSelector> | undefined;
+    if (node.elementPseudoClasses && toType === "block") {
+      elementPseudoClasses = [];
+      for (let pseudoclass of <Array<PseudoClassSelector>>node.elementPseudoClasses) { elementPseudoClasses.push(map(mapper, pseudoclass, fromType, toType)); }
+    }
+    let psuedoElement: PseudoElementSelector | undefined;
+    if (node.pseudoElement) {
+      psuedoElement = map(mapper, node.pseudoElement, fromType, toType);
+    }
+    let pseudoElementPseudoClasses: Array<PseudoClassSelector> | undefined;
+    if (node.pseudoElementPseudoClasses) {
+      pseudoElementPseudoClasses = [];
+      for (let pseudoclass of <Array<PseudoClassSelector>>node.pseudoElementPseudoClasses) { pseudoElementPseudoClasses.push(map(mapper, pseudoclass, fromType, toType)); }
+    }
+    let ret: CompoundSelector<isToDefinition, ForeignAttributeSelector | AttributeSelector, PseudoClassSelector, PseudoElementSelector>;
+    if (mapper.CompoundSelector) {
+      ret = mapper.CompoundSelector(element, attributes, elementPseudoClasses, psuedoElement, pseudoElementPseudoClasses);
+    } else {
+      // tslint:disable-next-line:prefer-unknown-to-any
+      ret = builders.compoundSelector(element, attributes, <any>elementPseudoClasses, psuedoElement, <any>pseudoElementPseudoClasses);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isScopeSelector(node)) {
+    let ret: ScopeSelector;
+    if (mapper.ScopeSelector) {
+      ret = mapper.ScopeSelector();
+    } else {
+      ret = builders.scopeSelector();
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isClassSelector(node)) {
+    let ret: ClassSelector;
+    if (mapper.ClassSelector) {
+      ret = mapper.ClassSelector(node.name);
+    } else {
+      ret = builders.classSelector(node.name);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isPseudoClassSelector(node)) {
+    let ret: PseudoClassSelector;
+    if (mapper.PseudoClassSelector) {
+      ret = mapper.PseudoClassSelector(node.name);
+    } else {
+      ret = builders.pseudoClassSelector(node.name);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isPseudoElementSelector(node)) {
+    let ret: PseudoElementSelector;
+    if (mapper.PseudoElementSelector) {
+      ret = mapper.PseudoElementSelector(node.name);
+    } else {
+      ret = builders.pseudoElementSelector(node.name);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isRule(node)) {
+    let selectors: Rule<isToDefinition>["selectors"] = [];
+    for (let sel of node.selectors) {
+      selectors.push(map(mapper, sel, fromType, toType));
+    }
+    let declarations: Rule<isToDefinition>["declarations"] = [];
+    for (let decl of node.declarations) {
+      declarations.push(map(mapper, decl, fromType, toType));
+    }
+    let ret: Rule<isToDefinition>;
+    if (mapper.Rule) {
+      ret = mapper.Rule(selectors, declarations);
+    } else {
+      ret = builders.rule(selectors, declarations);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isDeclaration(node)) {
+    let ret: Declaration;
+    if (mapper.Declaration) {
+      ret = mapper.Declaration(node.property, node.value);
+    } else {
+      ret = builders.declaration(node.property, node.value);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else if (typeguards.isGlobalDeclaration(node)) {
+    let selector = map(mapper, node.selector, fromType, toType);
+    let ret: GlobalDeclaration;
+    if (mapper.GlobalDeclaration) {
+      ret = mapper.GlobalDeclaration(selector);
+    } else {
+      ret = builders.globalDeclaration(selector);
+    }
+    // tslint:disable-next-line:prefer-unknown-to-any
+    return <any>ret;
+  } else {
+    throw new Error("internal error");
+  }
+}
+
+export function visit<isDefinition extends DefinitionAST | BlockAST>(visitor: Visitor<isDefinition>, node: Node<isDefinition>): void {
+  if (typeguards.isRoot(node)) {
+    if (visitor.Root) {
+      let result = visitor.Root(node);
+      if (result === false) return;
+    }
     for (let child of node.children) {
       visit(visitor, child);
     }
+  } else if (typeguards.isBlockSyntaxVersion(node)) {
+    if (visitor.BlockSyntaxVersion) {
+      let result = visitor.BlockSyntaxVersion(node);
+      if (result === false) {
+        return;
+      }
+    }
   } else if (typeguards.isBlockReference(node)) {
-    if (visitor.BlockReference) visitor.BlockReference(node);
+    if (visitor.BlockReference) {
+      let result = visitor.BlockReference(node);
+      if (result === false) {
+        return;
+      }
+    }
   } else if (typeguards.isBlockExport(node)) {
-    if (visitor.BlockExport) visitor.BlockExport(node);
+    if (visitor.BlockExport) {
+      let result = visitor.BlockExport(node);
+      if (result === false) {
+        return;
+      }
+    }
   } else if (typeguards.isLocalBlockExport(node)) {
-    if (visitor.LocalBlockExport) visitor.LocalBlockExport(node);
+    if (visitor.LocalBlockExport) {
+      let result = visitor.LocalBlockExport(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isComplexSelector(node)) {
+    if (visitor.ComplexSelector) {
+      let result = visitor.ComplexSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+    for (let ctx of node.contextSelectors) {
+      visit(visitor, ctx.selector);
+    }
+    visit(visitor, node.keySelector);
+  } else if (typeguards.isForeignAttributeSelector(node)) {
+    if (visitor.ForeignAttributeSelector) {
+      let result = visitor.ForeignAttributeSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isAttributeSelector(node)) {
+    if (visitor.AttributeSelector) {
+      let result = visitor.AttributeSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isCompoundSelector(node)) {
+    if (visitor.CompoundSelector) {
+      let result = visitor.CompoundSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+    visit(visitor, node.element);
+    if (node.attributes) {
+      for (let attr of node.attributes) { visit(visitor, attr); }
+    }
+    if (node.elementPseudoClasses) {
+      for (let pseudoclass of <Array<PseudoClassSelector>>node.elementPseudoClasses) { visit(visitor, pseudoclass); }
+    }
+    if (node.pseudoElement) {
+      visit(visitor, node.pseudoElement);
+    }
+    if (node.pseudoElementPseudoClasses) {
+      for (let pseudoclass of <Array<PseudoClassSelector>>node.pseudoElementPseudoClasses) { visit(visitor, pseudoclass); }
+    }
+  } else if (typeguards.isScopeSelector(node)) {
+    if (visitor.ScopeSelector) {
+      let result = visitor.ScopeSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isClassSelector(node)) {
+    if (visitor.ClassSelector) {
+      let result = visitor.ClassSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isPseudoClassSelector(node)) {
+    if (visitor.PseudoClassSelector) {
+      let result = visitor.PseudoClassSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isPseudoElementSelector(node)) {
+    if (visitor.PseudoElementSelector) {
+      let result = visitor.PseudoElementSelector(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isRule(node)) {
+    if (visitor.Rule) {
+      let result = visitor.Rule(node);
+      if (result === false) {
+        return;
+      }
+    }
+    for (let sel of node.selectors) {
+      visit(visitor, sel);
+    }
+    for (let decl of node.declarations) {
+      visit(visitor, decl);
+    }
+  } else if (typeguards.isDeclaration(node)) {
+    if (visitor.Declaration) {
+      let result = visitor.Declaration(node);
+      if (result === false) {
+        return;
+      }
+    }
+  } else if (typeguards.isGlobalDeclaration(node)) {
+    if (visitor.GlobalDeclaration) {
+      let result = visitor.GlobalDeclaration(node);
+      if (result === false) {
+        return;
+      }
+    }
+    visit(visitor, node.selector);
   } else {
     assertNever(node);
   }

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -45,7 +45,7 @@ export async function composeBlock(configuration: Configuration, root: postcss.R
           }
           let foundStyles = getStyleTargets(block, sel.selector);
           for (let blockClass of foundStyles.blockClasses) {
-            blockClass.addComposedStyle(refStyle, foundStyles.blockAttrs);
+            blockClass.addComposedStyle(refStyle, foundStyles.blockAttrs, refName);
           }
         }
       }

--- a/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/composes-block.ts
@@ -41,7 +41,7 @@ export async function composeBlock(configuration: Configuration, root: postcss.R
 
         for (let sel of parsedSel) {
           if (sel.selector.next) {
-            block.addError(new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a scope selector.`, sourceRange(configuration, root, sourceFile, decl)));
+            block.addError(new errors.InvalidBlockSyntax(`Style composition is not allowed in rule sets with a context selector.`, sourceRange(configuration, root, sourceFile, decl)));
           }
           let foundStyles = getStyleTargets(block, sel.selector);
           for (let blockClass of foundStyles.blockClasses) {

--- a/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/export-blocks.ts
@@ -5,9 +5,9 @@ import { Block } from "../../BlockTree";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
 import { allDone } from "../../util";
+import { BlockExport, LocalBlockExport, builders, typeguards } from "../ast";
 import { BlockFactory } from "../index";
 import { parseBlockNamesAST, stripQuotes } from "../utils";
-import { LocalBlockExport, BlockExport, builders, typeguards } from "../ast";
 
 const FROM_EXPR = /\s+from\s+/;
 

--- a/packages/@css-blocks/core/src/BlockParser/utils/blockNamesParser.ts
+++ b/packages/@css-blocks/core/src/BlockParser/utils/blockNamesParser.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_EXPORT } from "../../BlockSyntax";
+import { BlockReference } from "../ast";
 
 /**
  * Map of `aliasName` to `blockName`. Used to store data from `@block`
@@ -99,4 +100,27 @@ export function parseBlockNames(str: string, useDefault: boolean): BlockNames {
   commit(state);
   mapping[state.alias] = state.block;
   return mapping;
+}
+
+export function parseBlockNamesAST(blockList: string, useDefault: boolean) {
+  let defaultName: string | undefined;
+  let blockNames = parseBlockNames(blockList, useDefault);
+  let names: BlockReference["references"];
+  for (let asName of Object.keys(blockNames)) {
+    let name = blockNames[asName];
+    if (name === DEFAULT_EXPORT) {
+      defaultName = asName;
+    } else {
+      names = names || [];
+      if (name === asName) {
+        names.push({name});
+      } else {
+        names.push({name, asName});
+      }
+    }
+  }
+  return {
+    defaultName,
+    names,
+  };
 }

--- a/packages/@css-blocks/core/src/BlockParser/utils/index.ts
+++ b/packages/@css-blocks/core/src/BlockParser/utils/index.ts
@@ -1,2 +1,2 @@
-export { BlockNames, parseBlockNames } from "./blockNamesParser";
+export { BlockNames, parseBlockNames, parseBlockNamesAST } from "./blockNamesParser";
 export { stripQuotes } from "./stripQuotes";

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -538,7 +538,15 @@ export class Block
         return [klass, 0];
       }
     } else if (isAttributeNode(node)) {
-      let attr = this.rootClass.ensureAttributeValue(toAttrToken(node));
+      let prevNode = node.prev();
+      while (prevNode && !(selectorParser.isClassName(prevNode) || isRootNode(prevNode))) {
+        prevNode = prevNode.prev();
+      }
+      if (!prevNode) {
+        throw new Error("internal error - illegal selector encountered after validation.");
+      }
+      let klass = this.getClass(prevNode.value);
+      let attr = klass?.getAttributeValue(toAttrToken(node));
       if (attr) {
         return [attr, 0];
       } else {

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -8,7 +8,7 @@ import {
 } from "opticss";
 
 import { isAttributeNode, isClassNode, isRootNode, toAttrToken } from "../BlockParser";
-import { DefinitionRoot as DefinitionAST, Root as BlockAST } from "../BlockParser/ast";
+import { Root as BlockAST } from "../BlockParser/ast";
 import { BlockPath, CLASS_NAME_IDENT, DEFAULT_EXPORT, ROOT_CLASS } from "../BlockSyntax";
 import { ResolvedConfiguration } from "../configuration";
 import { CssBlockError, InvalidBlockSyntax, MultipleCssBlockErrors } from "../errors";
@@ -39,7 +39,6 @@ export class Block
   extends Inheritable<Block, Block, never, BlockClass> {
 
   public blockAST?: BlockAST;
-  public definitionAST?: DefinitionAST;
   private _blockReferences: ObjectDictionary<Block> = {};
   private _blockReferencesReverseLookup: Map<Block, string> = new Map();
   private _blockExports: ObjectDictionary<Block> = {};

--- a/packages/@css-blocks/core/src/BlockTree/Block.ts
+++ b/packages/@css-blocks/core/src/BlockTree/Block.ts
@@ -7,8 +7,8 @@ import {
   postcssSelectorParser as selectorParser,
 } from "opticss";
 
-import { isAttributeNode, isClassNode } from "../BlockParser";
-import { isRootNode, toAttrToken } from "../BlockParser";
+import { isAttributeNode, isClassNode, isRootNode, toAttrToken } from "../BlockParser";
+import { DefinitionRoot as DefinitionAST, Root as BlockAST } from "../BlockParser/ast";
 import { BlockPath, CLASS_NAME_IDENT, DEFAULT_EXPORT, ROOT_CLASS } from "../BlockSyntax";
 import { ResolvedConfiguration } from "../configuration";
 import { CssBlockError, InvalidBlockSyntax, MultipleCssBlockErrors } from "../errors";
@@ -38,6 +38,8 @@ import { Styles } from "./Styles";
 export class Block
   extends Inheritable<Block, Block, never, BlockClass> {
 
+  public blockAST?: BlockAST;
+  public definitionAST?: DefinitionAST;
   private _blockReferences: ObjectDictionary<Block> = {};
   private _blockReferencesReverseLookup: Map<Block, string> = new Map();
   private _blockExports: ObjectDictionary<Block> = {};

--- a/packages/@css-blocks/core/src/BlockTree/BlockClass.ts
+++ b/packages/@css-blocks/core/src/BlockTree/BlockClass.ts
@@ -26,6 +26,7 @@ function ensureToken(input: AttrToken | string): AttrToken {
 export interface Composition {
   style: Styles;
   conditions: AttrValue[];
+  path: string;
 }
 
 /**
@@ -274,8 +275,8 @@ export class BlockClass extends Style<BlockClass, Block, Block, Attribute> {
    *       of logic between css and template files and only resolve them to the
    *       requested language interface at rewrite time.
    */
-  addComposedStyle(style: Styles, conditions: AttrValue[]): void {
-    this._composedStyles.add({ style, conditions });
+  addComposedStyle(style: Styles, conditions: AttrValue[], path: string): void {
+    this._composedStyles.add({ style, conditions, path });
   }
 
   /**

--- a/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
@@ -87,7 +87,7 @@ export class BlockNames extends BEMProcessor {
     return assertMultipleErrorsRejection(
       [{
       type: InvalidBlockSyntax,
-      message: `Style composition is not allowed in rule sets with a scope selector. (foo/bar/test-block.css:2:44)`}],
+      message: `Style composition is not allowed in rule sets with a context selector. (foo/bar/test-block.css:2:44)`}],
       this.process(filename, inputCSS, {importer: imports.importer()}));
   }
 

--- a/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
+++ b/packages/@css-blocks/core/test/BlockParser/block-composition-test.ts
@@ -155,7 +155,7 @@ export class BlockNames extends BEMProcessor {
         indented`
           .test-block__bar { }
           .test-block__bar--active { }
-          .test-block__bar--color.test-block--inverse { background: blue; }
+          .test-block__bar--color.test-block__bar--inverse { background: blue; }
           /* Source: foo/bar/test-block.css
            * :scope (.test-block)
            *  composes:

--- a/packages/@css-blocks/core/test/block-definition-test.ts
+++ b/packages/@css-blocks/core/test/block-definition-test.ts
@@ -1,0 +1,144 @@
+import { assert } from "chai";
+import { only, suite, test } from "mocha-typescript";
+import { postcss } from "opticss";
+
+import * as cssBlocks from "../src";
+import { Block, BlockCompiler, BlockFactory } from "../src";
+import { BlockDefinitionCompiler } from "../src/BlockCompiler/BlockDefinitionCompiler";
+
+import { BEMProcessor } from "./util/BEMProcessor";
+import { setupImporting } from "./util/setupImporting";
+
+function lines(text: string): Array<string> {
+  return text.split("\n").map(l => l.trim()).filter(Boolean);
+}
+
+function clean(text: string): string {
+  return lines(text).join(" ").replace(/\s+/g, " ");
+}
+
+async function compileBlockWithDefinition(factory: BlockFactory, blockFilename: string): Promise<{block: Block; cssResult: postcss.Result; definitionResult: postcss.Result}> {
+  let config = factory.configuration;
+  let importer = config.importer;
+  let block = await factory.getBlock(importer.identifier(null, blockFilename, config));
+  let definitionCompiler = new BlockDefinitionCompiler(postcss, (_b, p) => p.replace(".block", ""), config);
+  let compiler = new BlockCompiler(postcss, config);
+  compiler.setDefinitionCompiler(definitionCompiler);
+  let definitionFilename = blockFilename.replace(".block", ".block.d");
+  let {css, definition} = compiler.compileWithDefinition(block, block.stylesheet!, new Set(), definitionFilename);
+  let cssFilename = blockFilename.replace(".block", "");
+  let cssResult = css.toResult({to: cssFilename});
+  let definitionResult = definition.toResult({to: definitionFilename});
+  return {block, cssResult, definitionResult};
+}
+
+@suite("Block Factory")
+export class BlockFactoryTests extends BEMProcessor {
+  assertError(errorType: typeof cssBlocks.CssBlockError, message: string, promise: postcss.LazyResult) {
+    return promise.then(
+      () => {
+        assert(false, `Error ${errorType.name} was not raised.`);
+      },
+      (reason) => {
+        assert(reason instanceof errorType, reason.toString());
+        assert.deepEqual(reason.message, message);
+      });
+  }
+
+  @only
+  @test async "can generate a definition"() {
+    let { imports, factory } = setupImporting();
+    let filename = "test-block.block.css";
+    imports.registerSource(
+      filename,
+      `:scope { color: purple; }
+       :scope[large] { font-size: 20px; }
+       .foo   { float: left; block-alias: foo "another-foo"; }
+       .foo[size=small] { font-size: 5px; }`,
+    );
+    let {block, cssResult, definitionResult} = await compileBlockWithDefinition(factory, filename);
+    assert.deepEqual(
+      clean(cssResult.css),
+      clean(`/*#css-blocks ${block.guid}*/
+       .test-block { color: purple; }
+       .test-block--large { font-size: 20px; }
+       .test-block__foo   { float: left;   }
+       .test-block__foo--size-small { font-size: 5px; }
+       /*#blockDefinitionURL=test-block.block.d.css*/
+       /*#css-blocks end*/`),
+    );
+    assert.deepEqual(
+      clean(definitionResult.css),
+      clean(`@block-syntax-version 1;
+       :scope { block-id: "${block.guid}"; block-name: "test-block"; block-class: test-block; block-interface-index: 0 }
+       :scope[large] { block-class: test-block--large; block-interface-index: 2 }
+       .foo { block-class: test-block__foo; block-interface-index: 3; block-alias: foo another-foo }
+       .foo[size="small"] { block-class: test-block__foo--size-small; block-interface-index: 5 }
+      `));
+  }
+
+  @only
+  @test async "can generate a definition with block-global declarations."() {
+    let { imports, factory } = setupImporting();
+    let filename = "test-block.block.css";
+    imports.registerSource(
+      filename,
+      `@block-global [large];
+       @block-global [mode=active];`,
+    );
+    let {block, definitionResult} = await compileBlockWithDefinition(factory, filename);
+    assert.deepEqual(
+      clean(definitionResult.css),
+      clean(`@block-syntax-version 1;
+       @block-global [large];
+       @block-global [mode="active"];
+       :scope { block-id: "${block.guid}"; block-name: "test-block"; block-class: test-block; block-interface-index: 0 }
+       :scope[large] { block-class: test-block--large; block-interface-index: 2 }
+       :scope[mode="active"] { block-class: test-block--mode-active; block-interface-index: 4 }
+      `));
+  }
+
+  @only
+  @test async "can generate a definition with a block reference"() {
+    let { imports, factory } = setupImporting();
+    imports.registerSource(
+      "foo.block.css",
+      `:scope { color: blue; }`,
+    );
+    imports.registerSource(
+      "bar/bip.block.css",
+      `:scope { color: orange; }`,
+    );
+    imports.registerSource(
+      "bar/baz.block.css",
+      `:scope { color: red; }`,
+    );
+    imports.registerSource(
+      "bar.block.css",
+      `@export (default as bip) from "./bar/bip.block.css";
+       @export (default as baz) from "./bar/baz.block.css"`,
+    );
+    let filename = "test-block.block.css";
+    imports.registerSource(
+      filename,
+      `@block foo from "./foo.block.css";
+       @block bar, (bip, baz as zab) from "./bar.block.css";
+       :scope { color: purple; }
+       `,
+    );
+    let {block, cssResult, definitionResult} = await compileBlockWithDefinition(factory, filename);
+    assert.deepEqual(
+      clean(cssResult.css),
+      clean(`/*#css-blocks ${block.guid}*/
+       .test-block { color: purple; }
+       /*#blockDefinitionURL=test-block.block.d.css*/
+       /*#css-blocks end*/`),
+    );
+    assert.deepEqual(
+      clean(definitionResult.css),
+      clean(`@block-syntax-version 1;
+       @block foo from "./foo.css";
+       @block bar, (bip, baz as zab) from "./bar.css";
+       :scope { block-id: "${block.guid}"; block-name: "test-block"; block-class: test-block; block-interface-index: 0 }`));
+  }
+}

--- a/packages/@css-blocks/core/test/util/postcss-helper.ts
+++ b/packages/@css-blocks/core/test/util/postcss-helper.ts
@@ -36,7 +36,7 @@ class Plugin {
    * @param  root  PostCSS AST
    * @param  result  Provides the result of the PostCSS transformations
    */
-  public async process(root: postcss.Root, result: postcss.Result) {
+  public process(root: postcss.Root, result: postcss.Result): Promise<postcss.Root> {
 
     // Fetch the CSS source file path. Throw if not present.
     let sourceFile: string;
@@ -52,9 +52,9 @@ class Plugin {
     let factory = new BlockFactory(this.config, this.postcss);
     const isDfnFile = this.mockConfigOpts.dfnFiles ? this.mockConfigOpts.dfnFiles.includes(identifier) : false;
 
-    await factory.parseRoot(root, sourceFile, defaultName, isDfnFile).then((block) => {
+    return factory.parseRoot(root, sourceFile, defaultName, isDfnFile).then((block) => {
       let compiler = new BlockCompiler(postcss, this.config);
-      compiler.compile(block, root, new Set());
+      return compiler.compile(block, root, new Set());
     });
   }
 }

--- a/packages/@css-blocks/core/test/util/setupImporting.ts
+++ b/packages/@css-blocks/core/test/util/setupImporting.ts
@@ -19,5 +19,6 @@ export function setupImporting(opts?: Partial<Readonly<Configuration>>) {
     importer,
     config,
     factory,
+    postcss,
   };
 }

--- a/packages/@css-blocks/ember/src/BroccoliFileLocator.ts
+++ b/packages/@css-blocks/ember/src/BroccoliFileLocator.ts
@@ -17,7 +17,7 @@ export class BroccoliFileLocator implements FileLocator {
     return `broccoli-tree:${relativePathToStylesheet}`;
   }
   possibleTemplatePaths(): Array<string> {
-    return this.fs.entries(".", ["**/*.hbs"]).map(e => e.relativePath);
+    return this.fs.entries(".", {globs: ["**/*.hbs"]}).map(e => e.relativePath);
   }
   possibleStylesheetPathsForTemplate(templatePath: string, extensions: Array<string>): Array<string> {
     let path = templatePath.replace("/templates/", "/styles/");

--- a/packages/@css-blocks/ember/src/index.ts
+++ b/packages/@css-blocks/ember/src/index.ts
@@ -1,4 +1,4 @@
-import config from "@css-blocks/config";
+import * as config from "@css-blocks/config";
 import { AnalysisOptions, Block, BlockCompiler, BlockFactory, Configuration, NodeJsImporter, Options as ParserOptions, OutputMode, resolveConfiguration } from "@css-blocks/core";
 import type { ASTPlugin, ASTPluginEnvironment } from "@glimmer/syntax";
 import { ObjectDictionary } from "@opticss/util";
@@ -77,7 +77,7 @@ class CSSBlocksTemplateCompilerPlugin extends TemplateCompilerPlugin {
     if (!this.output) {
       this.output = outputWrapper(this);
     }
-    let cssBlockEntries = this.input.entries(".", [BLOCK_GLOB]);
+    let cssBlockEntries = this.input.entries(".", {globs: [BLOCK_GLOB]});
     let currentFSTree = FSTree.fromEntries(cssBlockEntries);
     let patch = this.previousSourceTree.calculatePatch(currentFSTree);
     let removedFiles = patch.filter((change) => change[0] === "unlink");

--- a/packages/@css-blocks/ember/tsconfig.json
+++ b/packages/@css-blocks/ember/tsconfig.json
@@ -4,6 +4,7 @@
     "composite": true,
     "outDir": "dist",
     "baseUrl": "dist",
+    "noImplicitAny": false,
     "paths": {
       "*": ["types/*"],
     }

--- a/packages/@css-blocks/ember/types/async-disk-cache/index.d.ts
+++ b/packages/@css-blocks/ember/types/async-disk-cache/index.d.ts
@@ -1,0 +1,21 @@
+declare module 'async-disk-cache' {
+  namespace AsyncDiskCache {
+    export interface Options {
+      location?: string | undefined;
+      compression?: 'deflate';
+    }
+  }
+
+  interface CacheEntry<T> {
+    isCached: boolean;
+    value: T;
+  }
+
+  class AsyncDiskCache {
+    root: string;
+    constructor(cacheKey: string, options: AsyncDiskCache.Options)
+    get<T>(key: string): Promise<CacheEntry<T>>;
+    set<T>(key: string, value: T): Promise<void>;
+  }
+  export = AsyncDiskCache;
+}

--- a/packages/@css-blocks/ember/types/async-promise-queue/index.d.ts
+++ b/packages/@css-blocks/ember/types/async-promise-queue/index.d.ts
@@ -1,0 +1,8 @@
+declare module 'async-promise-queue' {
+  import * as Async from 'async';
+  function queue<T extends Function>(worker: Async.AsyncWorker<T>, Work: Array<T>, concurrency: number): Promise<void>;
+  namespace queue {
+    export const async: typeof Async;
+  }
+  export = queue;
+}

--- a/packages/@css-blocks/ember/types/hash-for-dep/index.d.ts
+++ b/packages/@css-blocks/ember/types/hash-for-dep/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'hash-for-dep' {
+  function hashForDep(path: string): string;
+  export = hashForDep;
+}

--- a/packages/@css-blocks/ember/types/heimdalljs-logger/index.d.ts
+++ b/packages/@css-blocks/ember/types/heimdalljs-logger/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'heimdalljs-logger' {
+  namespace loggerGenerator {
+    interface Logger {
+      info(...args: Array<unknown>): void;
+      debug(...args: Array<unknown>): void;
+    }
+  }
+  function loggerGenerator(name: string): loggerGenerator.Logger;
+  export = loggerGenerator;
+}

--- a/packages/@css-blocks/ember/types/heimdalljs/index.d.ts
+++ b/packages/@css-blocks/ember/types/heimdalljs/index.d.ts
@@ -1,0 +1,14 @@
+declare module 'heimdalljs' {
+  interface Schema<T> {
+    new (): T;
+  }
+  interface Node<T> {
+    stats: T;
+    stop(): void;
+  }
+  namespace heimdall {
+    export function start<T>(label: string, schema?: Schema<T>): Node<T>;
+    export function node<T, R>(label: string, schema: Schema<T>, callback: (instrumentation: T) => R): R;
+  }
+  export = heimdall;
+}

--- a/packages/@css-blocks/ember/types/promise-map-series/index.d.ts
+++ b/packages/@css-blocks/ember/types/promise-map-series/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'promise-map-series' {
+  function mapSeries<T,R>(series: Array<T>, mapper: (s: T) => R): Array<R>;
+  export = mapSeries;
+}

--- a/packages/@css-blocks/ember/types/sync-disk-cache/index.d.ts
+++ b/packages/@css-blocks/ember/types/sync-disk-cache/index.d.ts
@@ -1,0 +1,20 @@
+declare module 'sync-disk-cache' {
+  namespace SyncDiskCache {
+    export interface Options {
+      location?: string | undefined;
+    }
+  }
+
+  interface CacheEntry<T> {
+    isCached: boolean;
+    value: T;
+  }
+
+  class SyncDiskCache {
+    root: string;
+    constructor(cacheKey: string, options: SyncDiskCache.Options)
+    get<T>(key: string): CacheEntry<T>;
+    set<T>(key: string, value: T): void;
+  }
+  export = SyncDiskCache;
+}


### PR DESCRIPTION
This PR gets the basics of block definition compilation working. Two aspects of block definition files are omitted from this PR (`inherited-styles` and conflict resolutions). These aspects are important for pre-compilation but don't block our current project.

In this PR I introduce a CSS-Blocks specific AST that describes both legal CSS Block files as well as legal Block Definition Files. I use this AST first to construct a partial CSS Block AST during block parsing this is then "mapped" to a definition AST during block compilation. The rest of the AST is built up by examining the Block data model. Once the block definition AST is constructed I use an AST visitor to create the postcss AST which is then stringified.