### PR TITLE
Definition File Full Workflow - Acceptance Tests

### DIFF
--- a/packages/@css-blocks/core/src/BlockCompiler/index.ts
+++ b/packages/@css-blocks/core/src/BlockCompiler/index.ts
@@ -18,7 +18,7 @@ import {
 import { BlockDefinitionCompiler, INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
 import { ConflictResolver } from "./ConflictResolver";
 
-export { INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
+export { BlockDefinitionCompiler, INLINE_DEFINITION_FILE } from "./BlockDefinitionCompiler";
 
 export interface CompiledBlockAndDefinition {
   definitionPath: string;

--- a/packages/@css-blocks/core/src/BlockParser/features/add-preset-selectors.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/add-preset-selectors.ts
@@ -30,7 +30,7 @@ export function addPresetSelectors(configuration: Configuration, root: postcss.R
 
     // Find the block-class declaration...
     rule.walkDecls("block-class", decl => {
-      const val = stripQuotes(decl.value);
+      const val = stripQuotes(decl.value.trim());
 
       // Test that this actually could be a class name.
       if (!CLASS_NAME_IDENT.test(val)) {

--- a/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
+++ b/packages/@css-blocks/core/src/BlockParser/features/discover-name.ts
@@ -4,6 +4,7 @@ import { BLOCK_NAME, CLASS_NAME_IDENT } from "../../BlockSyntax";
 import { Configuration } from "../../configuration";
 import * as errors from "../../errors";
 import { sourceRange } from "../../SourceLocation";
+import { stripQuotes } from "../utils";
 
 export async function discoverName(configuration: Configuration, root: postcss.Root, file: string, isDfnFile: boolean, defaultName: string): Promise<string> {
   let foundName: string | undefined;
@@ -13,14 +14,15 @@ export async function discoverName(configuration: Configuration, root: postcss.R
   root.walkRules(":scope", (rule) => {
     scopeRule = rule;
     rule.walkDecls(BLOCK_NAME, (decl) => {
-      if (!CLASS_NAME_IDENT.test(decl.value)) {
+      const unquotedVal = stripQuotes(decl.value.trim());
+      if (!CLASS_NAME_IDENT.test(unquotedVal)) {
         throw new errors.InvalidBlockSyntax(
           `Illegal block name. '${decl.value}' is not a legal CSS identifier.`,
           sourceRange(configuration, root, file, decl),
         );
       }
 
-      foundName = decl.value.trim();
+      foundName = unquotedVal;
 
     });
   });

--- a/packages/@css-blocks/core/src/importing/NodeJsImporter.ts
+++ b/packages/@css-blocks/core/src/importing/NodeJsImporter.ts
@@ -14,7 +14,12 @@ const debug = debugGenerator("css-blocks:importer");
 
 const DEFAULT_MAIN = "blocks/index.block.css";
 
-const EMBEDDED_DEFINITION_TAG = "#blockDefinitionURL";
+/**
+ * A tag that's used to generate unique identifiers for embedded definition data.
+ * This is appended to the file identifier of the CSS file the embedded data was
+ * originally read from.
+ */
+export const EMBEDDED_DEFINITION_TAG = "#blockDefinitionURL";
 
 export interface CSSBlocksPackageMetadata {
   "css-blocks"?: {

--- a/packages/@css-blocks/core/test/acceptance/DfnFilesFullWorkflow.ts
+++ b/packages/@css-blocks/core/test/acceptance/DfnFilesFullWorkflow.ts
@@ -1,0 +1,327 @@
+import { assert } from "chai";
+import { suite, test } from "mocha-typescript";
+import { outdent } from "outdent";
+
+import { BlockCompiler, BlockDefinitionCompiler, INLINE_DEFINITION_FILE } from "../../src";
+import { REGEXP_COMMENT_DEFINITION_REF } from "../../src/PrecompiledDefinitions";
+import { setupImporting } from "../util/setupImporting";
+
+@suite("Acceptance Test - Definition Files Full Workflow")
+export class AcceptanceTestDefinitionFilesFullWorkflow {
+
+  @test async "Process basic CSS Blocks source file and parse from definition file, using mock importer"() {
+    // Setup our infrastructure... we need an importer, compiler, and parser ready to go.
+    let { imports, config, factory, postcss } = setupImporting();
+    const blockDfnCompiler = new BlockDefinitionCompiler(postcss, (_b, p) => p.replace(".block", ""), config);
+    const compiler = new BlockCompiler(postcss, config);
+    compiler.setDefinitionCompiler(blockDfnCompiler);
+
+    // Part 1: Given a basic CSS Blocks source file, generate a definition file.
+    imports.registerSource(
+      "/foo/bar/source.block.css",
+      outdent`
+        :scope { background-color: #FFF; }
+        :scope[toggled] { color: #000; }
+        :scope[foo="bar"] { border-top-color: #F00; }
+        .item { width: 100px; }
+        .item[toggled] { height: 100px; }
+        .item[foo="bar"] { min-width: 100px; }
+        .item + .item { border-left-color: #F00; }
+        :scope[toggled] .item { border-right-color: #F00; }
+        :scope[toggled] .item[foo="bar"] { border-bottom-color: #F00; }
+      `,
+    );
+    const originalBlock = await factory.getBlockFromPath("/foo/bar/source.block.css");
+
+    const { css: cssTree, definition: definitionTree } = compiler.compileWithDefinition(originalBlock, originalBlock.stylesheet!, new Set(), "/foo/bar/source.block.d.css");
+    const compiledCss = cssTree.toString();
+    const definition = definitionTree.toString();
+
+    // Test that the compiled content that we just generated is as expected.
+    assert.equal(
+      outdent`
+        ${compiledCss}
+      `,
+      outdent`
+        /*#css-blocks ${originalBlock.guid}*/
+        .source { background-color: #FFF; }
+        .source--toggled { color: #000; }
+        .source--foo-bar { border-top-color: #F00; }
+        .source__item { width: 100px; }
+        .source__item--toggled { height: 100px; }
+        .source__item--foo-bar { min-width: 100px; }
+        .source__item + .source__item { border-left-color: #F00; }
+        .source--toggled .source__item { border-right-color: #F00; }
+        .source--toggled .source__item--foo-bar { border-bottom-color: #F00; }
+        /*#blockDefinitionURL=/foo/bar/source.block.d.css*/
+        /*#css-blocks end*/
+      `,
+      "Compiled CSS contents match expected output",
+    );
+    assert.equal(
+      outdent`
+        ${definition}
+      `,
+      outdent`
+        @block-syntax-version 1;
+        :scope {
+            block-id: "${originalBlock.guid}";
+            block-name: "source";
+            block-class: source;
+            block-interface-index: 0
+        }
+        :scope[toggled] {
+            block-class: source--toggled;
+            block-interface-index: 2
+        }
+        :scope[foo="bar"] {
+            block-class: source--foo-bar;
+            block-interface-index: 4
+        }
+        .item {
+            block-class: source__item;
+            block-interface-index: 5
+        }
+        .item[toggled] {
+            block-class: source__item--toggled;
+            block-interface-index: 7
+        }
+        .item[foo="bar"] {
+            block-class: source__item--foo-bar;
+            block-interface-index: 9
+        }
+      `,
+      "Compiled definition contents match expected output",
+    );
+
+    // Part 2: Reset the importer and factory instances and try importing
+    //         the compiled css and definition data we just created.
+    imports.reset();
+    factory.reset();
+
+    imports.registerCompiledCssSource(
+      "/foo/bar/source.css",
+      compiledCss,
+      "/foo/bar/source.block.d.css",
+      definition,
+    );
+    const reconstitutedBlock = await factory.getBlockFromPath("/foo/bar/source.css");
+
+    // And now some checks to validate that we were able to reconstitute accurately.
+    assert.equal(reconstitutedBlock.guid, originalBlock.guid, "GUIDs of original and reconstituted blocks match");
+    assert.equal(reconstitutedBlock.name, originalBlock.name, "Names of original and reconstituted blocks match");
+
+    const expectedProperties = {
+      "source": {
+        "::self": [
+          "background-color",
+        ],
+      },
+      "source--toggled": {
+        "::self": [
+          "color",
+        ],
+      },
+      "source--foo-bar": {
+        "::self": [
+          "border-top-color",
+        ],
+      },
+      "source__item": {
+        "::self": [
+          "width",
+          "border-left-color",
+          "border-right-color",
+        ],
+      },
+      "source__item--toggled": {
+        "::self": [
+          "height",
+        ],
+      },
+      "source__item--foo-bar": {
+        "::self": [
+          "min-width",
+          "border-bottom-color",
+        ],
+      },
+    };
+    const expectedFoundClasses = Object.keys(expectedProperties);
+    const foundClasses = reconstitutedBlock.presetClassesMap(true);
+    assert.deepEqual(
+      Object.keys(foundClasses),
+      expectedFoundClasses,
+      "Class nodes on reconstituted block matches expected list of classes",
+    );
+    expectedFoundClasses.forEach(expectedClass => {
+      Object.keys(expectedProperties[expectedClass]).forEach(psuedo => {
+        assert.deepEqual(
+          [...foundClasses[expectedClass].rulesets.getProperties(psuedo)].sort(),
+          expectedProperties[expectedClass][psuedo].sort(),
+          `Properties on reconstituted class node ${expectedClass}${psuedo} match expected list`,
+        );
+      });
+    });
+  }
+
+  @test async "Process basic CSS Blocks source file and parse from embedded definitions, using mock importer"() {
+    // Setup our infrastructure... we need an importer, compiler, and parser ready to go.
+    let { imports, config, factory, postcss } = setupImporting();
+    const blockDfnCompiler = new BlockDefinitionCompiler(postcss, (_b, p) => p.replace(".block", ""), config);
+    const compiler = new BlockCompiler(postcss, config);
+    compiler.setDefinitionCompiler(blockDfnCompiler);
+
+    // Part 1: Given a basic CSS Blocks source file, generate a definition file.
+    imports.registerSource(
+      "/foo/bar/source.block.css",
+      outdent`
+        :scope { background-color: #FFF; }
+        :scope[toggled] { color: #000; }
+        :scope[foo="bar"] { border-top-color: #F00; }
+        .item { width: 100px; }
+        .item[toggled] { height: 100px; }
+        .item[foo="bar"] { min-width: 100px; }
+        .item + .item { border-left-color: #F00; }
+        :scope[toggled] .item { border-right-color: #F00; }
+        :scope[toggled] .item[foo="bar"] { border-bottom-color: #F00; }
+      `,
+    );
+    const originalBlock = await factory.getBlockFromPath("/foo/bar/source.block.css");
+
+    const { css: cssTree } = compiler.compileWithDefinition(originalBlock, originalBlock.stylesheet!, new Set(), INLINE_DEFINITION_FILE);
+    const compiledCss = cssTree.toString();
+
+    // Test that the compiled content that we just generated is as expected.
+    // Because the GUID isn't fixed, and a part of the base64 encoded blob, we'll
+    // need to remove it from the tested output and validate it separately.
+    const embeddedDfnRegexResult = REGEXP_COMMENT_DEFINITION_REF.exec(compiledCss);
+    if (!embeddedDfnRegexResult) {
+      assert.fail(false, true, "Expected to find embedded definition data");
+      return; // This isn't necessary, but TypeScript doesn't recognize that assert.fail() always throws.
+    }
+    const compiledCssNoDfn = compiledCss.replace(embeddedDfnRegexResult[0], "");
+    assert.equal(
+      outdent`
+        ${compiledCssNoDfn}
+      `,
+      outdent`
+        /*#css-blocks ${originalBlock.guid}*/
+        .source { background-color: #FFF; }
+        .source--toggled { color: #000; }
+        .source--foo-bar { border-top-color: #F00; }
+        .source__item { width: 100px; }
+        .source__item--toggled { height: 100px; }
+        .source__item--foo-bar { min-width: 100px; }
+        .source__item + .source__item { border-left-color: #F00; }
+        .source--toggled .source__item { border-right-color: #F00; }
+        .source--toggled .source__item--foo-bar { border-bottom-color: #F00; }
+        /*#css-blocks end*/
+      `,
+      "Compiled CSS contents match expected output",
+    );
+    assert.equal(
+      outdent`
+        ${Buffer.from(embeddedDfnRegexResult[1].split(",")[1], "base64").toString("utf-8")}
+      `,
+      outdent`
+        @block-syntax-version 1;
+        :scope {
+            block-id: "${originalBlock.guid}";
+            block-name: "source";
+            block-class: source;
+            block-interface-index: 0
+        }
+        :scope[toggled] {
+            block-class: source--toggled;
+            block-interface-index: 2
+        }
+        :scope[foo="bar"] {
+            block-class: source--foo-bar;
+            block-interface-index: 4
+        }
+        .item {
+            block-class: source__item;
+            block-interface-index: 5
+        }
+        .item[toggled] {
+            block-class: source__item--toggled;
+            block-interface-index: 7
+        }
+        .item[foo="bar"] {
+            block-class: source__item--foo-bar;
+            block-interface-index: 9
+        }
+      `,
+      "Unencoded definition data matches expected output",
+    );
+
+    // Part 2: Reset the importer and factory instances and try importing
+    //         the compiled css and definition data we just created.
+    imports.reset();
+    factory.reset();
+
+    imports.registerSource(
+      "/foo/bar/source.css",
+      compiledCss,
+      undefined,
+      true,
+    );
+    const reconstitutedBlock = await factory.getBlockFromPath("/foo/bar/source.css");
+
+    // And now some checks to validate that we were able to reconstitute accurately.
+    assert.equal(reconstitutedBlock.guid, originalBlock.guid, "GUIDs of original and reconstituted blocks match");
+    assert.equal(reconstitutedBlock.name, originalBlock.name, "Names of original and reconstituted blocks match");
+
+    const expectedProperties = {
+      "source": {
+        "::self": [
+          "background-color",
+        ],
+      },
+      "source--toggled": {
+        "::self": [
+          "color",
+        ],
+      },
+      "source--foo-bar": {
+        "::self": [
+          "border-top-color",
+        ],
+      },
+      "source__item": {
+        "::self": [
+          "width",
+          "border-left-color",
+          "border-right-color",
+        ],
+      },
+      "source__item--toggled": {
+        "::self": [
+          "height",
+        ],
+      },
+      "source__item--foo-bar": {
+        "::self": [
+          "min-width",
+          "border-bottom-color",
+        ],
+      },
+    };
+    const expectedFoundClasses = Object.keys(expectedProperties);
+    const foundClasses = reconstitutedBlock.presetClassesMap(true);
+    assert.deepEqual(
+      Object.keys(foundClasses),
+      expectedFoundClasses,
+      "Class nodes on reconstituted block matches expected list of classes",
+    );
+    expectedFoundClasses.forEach(expectedClass => {
+      Object.keys(expectedProperties[expectedClass]).forEach(psuedo => {
+        assert.deepEqual(
+          [...foundClasses[expectedClass].rulesets.getProperties(psuedo)].sort(),
+          expectedProperties[expectedClass][psuedo].sort(),
+          `Properties on reconstituted class node ${expectedClass}${psuedo} match expected list`,
+        );
+      });
+    });
+  }
+}

--- a/packages/@css-blocks/core/test/acceptance/DfnFilesFullWorkflow.ts
+++ b/packages/@css-blocks/core/test/acceptance/DfnFilesFullWorkflow.ts
@@ -67,28 +67,22 @@ export class AcceptanceTestDefinitionFilesFullWorkflow {
         :scope {
             block-id: "${originalBlock.guid}";
             block-name: "source";
-            block-class: source;
-            block-interface-index: 0
+            block-class: source
         }
         :scope[toggled] {
-            block-class: source--toggled;
-            block-interface-index: 2
+            block-class: source--toggled
         }
         :scope[foo="bar"] {
-            block-class: source--foo-bar;
-            block-interface-index: 4
+            block-class: source--foo-bar
         }
         .item {
-            block-class: source__item;
-            block-interface-index: 5
+            block-class: source__item
         }
         .item[toggled] {
-            block-class: source__item--toggled;
-            block-interface-index: 7
+            block-class: source__item--toggled
         }
         .item[foo="bar"] {
-            block-class: source__item--foo-bar;
-            block-interface-index: 9
+            block-class: source__item--foo-bar
         }
       `,
       "Compiled definition contents match expected output",
@@ -228,28 +222,22 @@ export class AcceptanceTestDefinitionFilesFullWorkflow {
         :scope {
             block-id: "${originalBlock.guid}";
             block-name: "source";
-            block-class: source;
-            block-interface-index: 0
+            block-class: source
         }
         :scope[toggled] {
-            block-class: source--toggled;
-            block-interface-index: 2
+            block-class: source--toggled
         }
         :scope[foo="bar"] {
-            block-class: source--foo-bar;
-            block-interface-index: 4
+            block-class: source--foo-bar
         }
         .item {
-            block-class: source__item;
-            block-interface-index: 5
+            block-class: source__item
         }
         .item[toggled] {
-            block-class: source__item--toggled;
-            block-interface-index: 7
+            block-class: source__item--toggled
         }
         .item[foo="bar"] {
-            block-class: source__item--foo-bar;
-            block-interface-index: 9
+            block-class: source__item--foo-bar
         }
       `,
       "Unencoded definition data matches expected output",

--- a/packages/@css-blocks/core/test/util/MockImportRegistry.ts
+++ b/packages/@css-blocks/core/test/util/MockImportRegistry.ts
@@ -10,6 +10,7 @@ import {
   ResolvedConfiguration,
   Syntax,
 } from "../../src";
+import { EMBEDDED_DEFINITION_TAG } from "../../src/importing/NodeJsImporter";
 
 const PROJECT_DIR = path.resolve(__dirname, "../../..");
 export interface SourceWithSyntax {
@@ -17,10 +18,15 @@ export interface SourceWithSyntax {
   syntax: Syntax;
   dfnContents?: string;
   dfnIdentifier?: string;
+  hasEmbeddedDfnData?: boolean;
 }
 export type SourceRegistry = ObjectDictionary<SourceWithSyntax>;
 export type ImportedFiles = ObjectDictionary<boolean>;
 
+/**
+ * A fake importer that behaves similar to the NodeJsImporter, but doesn't actually
+ * read any files from the file system.
+ */
 export class MockImporter extends NodeJsImporter {
   registry: MockImportRegistry;
   constructor(registry: MockImportRegistry) {
@@ -56,6 +62,22 @@ export class MockImporter extends NodeJsImporter {
         blockId: blockId,
         defaultName: this.defaultName(resolvedPath, configuration),
       };
+    } else if (source.hasEmbeddedDfnData) {
+      const parsedSourceContents = this.segmentizeCompiledBlockCSS(source.contents);
+      const blockCssContents = parsedSourceContents.blockCssContents;
+      const blockId = parsedSourceContents.blockId;
+      const definitionIdentifier = `${resolvedPath}${EMBEDDED_DEFINITION_TAG}`;
+      const definitionContents = Buffer.from(parsedSourceContents.definitionUrl.split(",")[1], "base64").toString("utf-8");
+      return {
+        type: "ImportedCompiledCssFile",
+        syntax: Syntax.css,
+        identifier: resolvedPath,
+        cssContents: blockCssContents,
+        definitionIdentifier,
+        definitionContents,
+        blockId: blockId,
+        defaultName: this.defaultName(resolvedPath, configuration),
+      };
     } else {
       return {
         type: "ImportedFile",
@@ -68,18 +90,39 @@ export class MockImporter extends NodeJsImporter {
   }
 }
 
+/**
+ * A registry of sources that the MockImporter can pull files from. When writing
+ * integration or acceptance tests, you can use this to avoid interacting with the
+ * file system directly.
+ */
 export class MockImportRegistry {
   sources: SourceRegistry = {};
   imported: ImportedFiles = {};
 
-  registerSource(sourcePath: string, contents: string, syntax?: Syntax) {
+  /**
+   * Register a source "file" that can be read by the MockImporter.
+   * @param sourcePath - The filepath the source can be looked up from.
+   * @param contents - The contents of the source.
+   * @param syntax - The syntax/format of the source data. Defaults to CSS.
+   * @param hasEmbeddedDfnData - Whether the source data includes embedded base64 definition data. Defaults to false.
+   */
+  registerSource(sourcePath: string, contents: string, syntax?: Syntax, hasEmbeddedDfnData?: boolean) {
     sourcePath = this.relativize(sourcePath);
     this.sources[sourcePath] = {
       contents: contents,
       syntax: syntax || Syntax.css,
+      hasEmbeddedDfnData: hasEmbeddedDfnData || false,
     };
   }
 
+  /**
+   * Registers a Compiled CSS source "file" and its associated definition "file" that can both
+   * be read by the MockImporter.
+   * @param sourcePath - The filepath the Compiled CSS can be looked up from.
+   * @param cssContents - The contents of the Compiled CSS.
+   * @param dfnIdentifier - The filepath the definition data can be looked up from.
+   * @param dfnContents - The contents of the definition data.
+   */
   registerCompiledCssSource(sourcePath: string, cssContents: string, dfnIdentifier: string, dfnContents: string) {
     sourcePath = this.relativize(sourcePath);
     this.sources[sourcePath] = {
@@ -90,11 +133,19 @@ export class MockImportRegistry {
     };
   }
 
+  /**
+   * Records that a particular source path has been imported.
+   * @param sourcePath - The source path to record as imported.
+   */
   markImported(sourcePath: string) {
     sourcePath = this.relativize(sourcePath);
     this.imported[sourcePath] = true;
   }
 
+  /**
+   * Assers that a particular source path has been imported by the MockImporter.
+   * @param sourcePath - The source path to assert was imported.
+   */
   assertImported(sourcePath: string) {
     sourcePath = this.relativize(sourcePath);
     if (!this.imported[sourcePath]) {
@@ -105,7 +156,12 @@ export class MockImportRegistry {
     }
   }
 
-  relativize(absolutePath: string) {
+  /**
+   * Given an absolute path, generate the relative path, relative to the root of /core.
+   * @param absolutePath - The absolute path to turn into a relative path.
+   * @returns The relative path.
+   */
+  relativize(absolutePath: string): string {
     if (absolutePath.startsWith(PROJECT_DIR)) {
       return absolutePath.slice(PROJECT_DIR.length + 1);
     } else {
@@ -113,7 +169,22 @@ export class MockImportRegistry {
     }
   }
 
+  /**
+   * Generates a new MockImporter associated with this MockImportRegistry instance.
+   * You can hand this importer off to other classes such as BlockFactory to import
+   * mock "files" from this registry.
+   * @returns The generated Importer instance.
+   */
   importer(): Importer {
     return new MockImporter(this);
+  }
+
+  /**
+   * Resets the sources and imported paths in this registry, without fully destroying
+   * the MockImporter or this instance.
+   */
+  reset() {
+    this.sources = {};
+    this.imported = {};
   }
 }


### PR DESCRIPTION
This PR includes two commits...

**fix: Allow quotes surrounding block-name.**
    
Definition file output wraps the block-name in quotes, but there are
existing rules in CSS Blocks disallowing this. This removes this rule,
using stripQuotes() to unwrap the block-name value. With this change,
block-name, block-id, and block-class will all behave in the same way.

**test: Definition Files Basic Acceptance Tests.**
    
- Test the full workflow of working with definition files. From a source
block file, compile it into css and definition data, then reconstitute
the block and validate the name, GUID, and properties match.
- Tests for both external definition files and embedded definition data.
- Update the mock importer to recognize embedded definition data.
- Add some comments to MockImporter and the registry.

------------------------

This PR only encompasses basic acceptance coverage using a source CSS Blocks file without any imports, exports, or aliases.

CI is going to fail because of missing types for `ember-cli-htmlbars`. Manually verified that `yarn test` in the `/core` directory is passing locally.