### PR TITLE
Establish ember-app addon!

### DIFF
--- a/packages/@css-blocks/ember-app/README.md
+++ b/packages/@css-blocks/ember-app/README.md
@@ -4,17 +4,14 @@
 
 # @css-blocks/ember-app
 
-An ember-cli addon for Ember applications using CSS Blocks in its application code. This addon should be a dependency in the following Ember artifacts...
+An ember-cli addon for Ember applications using CSS Blocks in its application code. This addon should be a dependency in Ember applications.
 
-- Ember applications.
-- Lazy Ember Engines.
-
-This addon is only part of the Ember build pipeline for CSS Blocks! Your application, as well as any addons you rely on, will need the `@css-blocks/ember` addon as a dependency if they have any CSS Blocks files.
+This addon is only part of the Ember build pipeline for CSS Blocks! Your application, as well as any addons or engines you rely on, will need the `@css-blocks/ember` addon as a dependency if they have any CSS Blocks files.
 
 ## Basic Usage
 
-1. Add this addon as a dependency to your application or lazy Ember Engine.
-2. Also make sure you add `@css-blocks/ember` as a dependency.
+1. Add this addon as a dependency to your application.
+2. Also make sure you add `@css-blocks/ember` as a dependency if you are authoring css using CSS Blocks.
 3. Run `ember build`.
 
 That's it! For development builds, we'll generate CSS output with some developer-friendly BEM class names so you can better understand your application. For production builds, you'll get a CSS artifact that's been concatenated and minified.

--- a/packages/@css-blocks/ember-app/README.md
+++ b/packages/@css-blocks/ember-app/README.md
@@ -1,0 +1,39 @@
+<p align="center">
+  <img alt="CSS Blocks" width="480px" src="http://css-blocks.com/static/media/wordmark-animated.012177e4.svg" />
+</p>
+
+# @css-blocks/ember-app
+
+An ember-cli addon for Ember applications using CSS Blocks in its application code. This addon should be a dependency in the following Ember artifacts...
+
+- Ember applications.
+- Lazy Ember Engines.
+
+This addon is only part of the Ember build pipeline for CSS Blocks! Your application, as well as any addons you rely on, will need the `@css-blocks/ember` addon as a dependency if they have any CSS Blocks files.
+
+## Basic Usage
+
+1. Add this addon as a dependency to your application or lazy Ember Engine.
+2. Also make sure you add `@css-blocks/ember` as a dependency.
+3. Run `ember build`.
+
+That's it! For development builds, we'll generate CSS output with some developer-friendly BEM class names so you can better understand your application. For production builds, you'll get a CSS artifact that's been concatenated and minified.
+
+This addon also provides a template helper for your application: `-css-blocks-`. We take a closer look at how this helper works in the Ember Build Pipeline Technical Deep Dive. The quick summary is that this helper figures out what styles to apply to any templates or components with an associated CSS Blocks file. Any templates that were previously compiled using the `@css-blocks/ember` addon will reference this helper, so you'll need to make sure you have it available in your app.
+
+## Options
+
+None at the moment, but when they're available, we'll document them here.
+
+## Common Gotchas
+
+This section is devoted to common issues you might run into when working with this addon.
+
+### Nothing yet...
+
+There's nothing here yet, but we'll add things here as the need arises.
+
+## More Reading
+
+- [CSS Blocks User Documentation](https://css-blocks.com/)
+- Ember Build Pipeline Technical Deep Dive - Link TBD

--- a/packages/@css-blocks/ember-app/package.json
+++ b/packages/@css-blocks/ember-app/package.json
@@ -5,8 +5,8 @@
   "main": "dist/src/index.js",
   "author": "Chris Eppstein <ceppstein@linkedin.com>",
   "license": "BSD-2-Clause",
-  "repository": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/ember",
-  "homepage": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/ember#readme",
+  "repository": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/ember-app",
+  "homepage": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/ember-app#readme",
   "keywords": [
     "css-blocks",
     "ember-addon"
@@ -43,9 +43,6 @@
     "typescript": "~3.8.3",
     "watch": "^1.0.2"
   },
-  "peerDependencies": {
-    "ember-cli-htmlbars": "^4.3.1"
-  },
   "dependencies": {
     "@css-blocks/config": "^1.0.0",
     "@css-blocks/core": "^1.0.0",
@@ -61,7 +58,6 @@
     "broccoli-plugin": "^4.0.0",
     "colors": "^1.2.1",
     "debug": "^4.1.1",
-    "ember-cli-htmlbars": "^5.2.0",
     "fs-extra": "^8.0.0",
     "fs-merger": "^3.0.2",
     "fs-tree-diff": "^2.0.0",
@@ -78,12 +74,6 @@
     "node": "10.* || >= 12.*"
   },
   "ember-addon": {
-    "before": [
-      "ember-cli-babel",
-      "ember-cli-htmlbars",
-      "ember-cli-sass",
-      "ember-cli-eyeglass"
-    ],
     "after": [
       "@css-blocks/ember"
     ]

--- a/packages/@css-blocks/ember-app/package.json
+++ b/packages/@css-blocks/ember-app/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "@css-blocks/ember-app",
+  "version": "0.1.0",
+  "description": "CSS Blocks Application Support for Ember.",
+  "main": "dist/src/index.js",
+  "author": "Chris Eppstein <ceppstein@linkedin.com>",
+  "license": "BSD-2-Clause",
+  "repository": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/ember",
+  "homepage": "https://github.com/linkedin/css-blocks/tree/master/packages/%40css-blocks/ember#readme",
+  "keywords": [
+    "css-blocks",
+    "ember-addon"
+  ],
+  "scripts": {
+    "test": "yarn run test:runner",
+    "test:runner": "mocha --opts test/mocha.opts dist/test",
+    "compile": "tsc --build",
+    "pretest": "yarn run compile",
+    "posttest": "yarn run lint",
+    "prepublish": "rm -rf dist && yarn run compile && yarn run lintall",
+    "lint": "tslint -t msbuild --project . -c tslint.cli.json",
+    "lintall": "tslint -t msbuild --project . -c tslint.release.json",
+    "lintfix": "tslint -t msbuild --project . -c tslint.cli.json --fix",
+    "coverage": "istanbul cover -i dist/src/**/*.js --dir ./build/coverage node_modules/mocha/bin/_mocha -- dist/test --opts test/mocha.opts",
+    "remap": "remap-istanbul -i build/coverage/coverage.json -o coverage -t html",
+    "watch": "watch 'yarn run test' src test --wait=1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@css-blocks/code-style": "^1.0.0",
+    "@css-blocks/glimmer": "^1.0.0",
+    "@types/chai-as-promised": "^7.1.2",
+    "@types/console-ui": "^2.2.3",
+    "@types/core-object": "^3.0.1",
+    "@types/express": "^4.17.6",
+    "@types/fs-extra": "^8.0.0",
+    "@types/glob": "^7.1.1",
+    "broccoli-node-api": "^1.7.0",
+    "broccoli-test-helper": "^2.0.0",
+    "chai-as-promised": "^7.1.1",
+    "typescript": "~3.8.3",
+    "watch": "^1.0.2"
+  },
+  "peerDependencies": {
+    "ember-cli-htmlbars": "^4.3.1"
+  },
+  "dependencies": {
+    "@css-blocks/config": "^1.0.0",
+    "@css-blocks/core": "^1.0.0",
+    "@css-blocks/glimmer": "^1.0.0",
+    "@glimmer/compiler": "^0.43.0",
+    "@glimmer/syntax": "^0.43.0",
+    "@opticss/template-api": "^0.6.3",
+    "@opticss/util": "^0.7.0",
+    "broccoli-debug": "^0.6.5",
+    "broccoli-funnel": "^3.0.2",
+    "broccoli-merge-trees": "^4.0.0",
+    "broccoli-output-wrapper": "^3.2.1",
+    "broccoli-plugin": "^4.0.0",
+    "colors": "^1.2.1",
+    "debug": "^4.1.1",
+    "ember-cli-htmlbars": "^5.2.0",
+    "fs-extra": "^8.0.0",
+    "fs-merger": "^3.0.2",
+    "fs-tree-diff": "^2.0.0",
+    "glob": "^7.1.2",
+    "opticss": "^0.7.0",
+    "symlink-or-copy": "^1.2.0",
+    "walk-sync": "^2.0.0"
+  },
+  "volta": {
+    "node": "12.2.0",
+    "yarn": "1.21.0"
+  },
+  "engines": {
+    "node": "10.* || >= 12.*"
+  },
+  "ember-addon": {
+    "before": [
+      "ember-cli-babel",
+      "ember-cli-htmlbars",
+      "ember-cli-sass",
+      "ember-cli-eyeglass"
+    ],
+    "after": [
+      "@css-blocks/ember"
+    ]
+  }
+}

--- a/packages/@css-blocks/ember-app/src/index.ts
+++ b/packages/@css-blocks/ember-app/src/index.ts
@@ -1,0 +1,105 @@
+import type { AddonImplementation } from "ember-cli/lib/models/addon";
+
+/**
+ * An ember-cli addon for Ember applications using CSS Blocks in its
+ * application code. This addon should be a dependency in the
+ * following Ember artifacts...
+ *
+ * - Ember applications.
+ * - Lazy Ember Engines.
+ *
+ * This addon is responsible for bundling together all CSS Blocks content
+ * from the application, concatenating it into a final artifact, and
+ * optimizing its content using OptiCSS. Additionaly, this addon generates a
+ * JSON bundle that contains runtime data that templates need to resolve
+ * what classes to add to each CSS Blocks-powered component. And, finally,
+ * this addon provides a runtime helper to actually write out those classes.
+ *
+ * This addon expects that all intermediary blocks have already been compiled
+ * into their respective Compiled CSS and Definition Files using the
+ * @css-blocks/ember addon. Your app should also include this as a dependency,
+ * or else this addon won't generate any CSS output!
+ *
+ * A friendly refresher for those that might've missed this tidbit from
+ * @css-blocks/ember... CSS Blocks actually compiles its CSS as part of the
+ * Template tree, not the styles tree! This is because CSS Blocks is unique
+ * in how it reasons about both your templates and styles together. So, in order
+ * to actually reason about both, and, in turn, rewrite your templates for you,
+ * both have to be processed when building templates.
+ *
+ * You can read more about CSS Blocks at...
+ * css-blocks.com
+ *
+ * And you can read up on the Ember build pipeline for CSS Blocks at...
+ * <LINK_TBD>
+ *
+ * @todo: Provide a link for Ember build pipeline readme.
+ */
+const EMBER_ADDON: AddonImplementation = {
+  /**
+   * The name of this addon. Generally matches the package name in package.json.
+   */
+  name: "@css-blocks/ember-app",
+
+  /**
+   * Initalizes this addon instance for use.
+   * @param parent - The project or addon that directly depends on this addon.
+   * @param project - The current project (deprecated).
+   */
+  init(parent, project) {
+    // We must call this._super or weird stuff happens. The Ember CLI docs
+    // recommend guarding this call, so we're gonna ask TSLint to chill.
+    // tslint:disable-next-line: no-unused-expression
+    this._super.init && this._super.init.call(this, parent, project);
+  },
+
+  /**
+   * This method is called when the addon is included in a build. You would typically
+   * use this hook to perform additional imports.
+   * @param parent - The parent addon or application this addon is currently working on.
+   */
+  included(parent) {
+    // We must call this._super or weird stuff happens.
+    this._super.included.apply(this, [parent]);
+  },
+
+  /**
+   * Pre-process a tree. Used for adding/removing files from the build.
+   * @param type - What kind of tree.
+   * @param tree - The tree that's to be processed.
+   * @returns - A tree that's ready to process.
+   */
+  preprocessTree(type, tree) {
+    if (type !== "template") return tree;
+
+    // TODO: Do something in the template tree.
+    return tree;
+  },
+
+  /**
+   * Post-process a tree. Runs after the files in this tree have been built.
+   * @param type - What kind of tree.
+   * @param tree  - The processed tree.
+   * @returns - The processed tree.
+   */
+  postprocessTree(type, tree) {
+    if (type !== "template") return tree;
+
+    // TODO: Do something in the template tree.
+    return tree;
+  },
+
+  /**
+   * Used to add preprocessors to the preprocessor registry. This is often used
+   * by addons like ember-cli-htmlbars and ember-cli-coffeescript to add a
+   * template or js preprocessor to the registry.
+   * @param _type - Either "self" or "parent".
+   * @param _registry - The registry to be set up.
+   */
+  setupPreprocessorRegistry(_type, _registry) {
+    // TODO: This hook may not be necessary in this addon.
+  },
+};
+
+// Aaaaand export the addon implementation!
+module.exports = EMBER_ADDON;

--- a/packages/@css-blocks/ember-app/src/index.ts
+++ b/packages/@css-blocks/ember-app/src/index.ts
@@ -2,11 +2,7 @@ import type { AddonImplementation } from "ember-cli/lib/models/addon";
 
 /**
  * An ember-cli addon for Ember applications using CSS Blocks in its
- * application code. This addon should be a dependency in the
- * following Ember artifacts...
- *
- * - Ember applications.
- * - Lazy Ember Engines.
+ * application code. This addon should be a dependency in Ember applications.
  *
  * This addon is responsible for bundling together all CSS Blocks content
  * from the application, concatenating it into a final artifact, and

--- a/packages/@css-blocks/ember-app/test/mocha.opts
+++ b/packages/@css-blocks/ember-app/test/mocha.opts
@@ -1,0 +1,4 @@
+--reporter spec
+--require source-map-support/register
+--inline-diffs
+dist/test/*.js

--- a/packages/@css-blocks/ember-app/tsconfig.json
+++ b/packages/@css-blocks/ember-app/tsconfig.json
@@ -19,7 +19,6 @@
     "test"
   ],
   "exclude": [
-    "sanity",
     "dist",
     "node_modules"
   ]

--- a/packages/@css-blocks/ember-app/tsconfig.json
+++ b/packages/@css-blocks/ember-app/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "baseUrl": "dist",
+    "noImplicitAny": false,
+    "paths": {
+      "*": ["types/*"],
+    }
+  },
+  "references": [
+    {"path": "../config"},
+    {"path": "../core"},
+    {"path": "../glimmer"}
+  ],
+  "include": [
+    "src",
+    "test"
+  ],
+  "exclude": [
+    "sanity",
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/@css-blocks/ember-app/tslint.cli.json
+++ b/packages/@css-blocks/ember-app/tslint.cli.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": "@css-blocks/code-style/configs/tslint.cli.json"
+}

--- a/packages/@css-blocks/ember-app/tslint.json
+++ b/packages/@css-blocks/ember-app/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@css-blocks/code-style/configs/tslint.cli.json"
+}

--- a/packages/@css-blocks/ember-app/tslint.release.json
+++ b/packages/@css-blocks/ember-app/tslint.release.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": "@css-blocks/code-style/configs/tslint.release.json"
+}

--- a/private-packages/fixtures-ember-v2/ember-app.code-workspace
+++ b/private-packages/fixtures-ember-v2/ember-app.code-workspace
@@ -1,20 +1,31 @@
 {
 	"folders": [
 		{
-			"path": "../../packages/@css-blocks/ember"
+			"path": "../../packages/@css-blocks/ember",
+			"name": "Addon: Ember"
 		},
 		{
-			"path": "ember-engine"
+			"path": "../../packages/@css-blocks/ember-app",
+			"name": "Addon: Ember App"
 		},
 		{
-			"path": "ember-addon"
+			"path": "ember-app",
+			"name": "Fixture: Ember App"
 		},
 		{
-			"path": "ember-app"
+			"path": "ember-addon",
+			"name": "Fixture: Ember Addon"
 		},
 		{
-			"path": "ember-lazy-engine"
+			"path": "ember-engine",
+			"name": "Fixture: Ember Engine"
+		},
+		{
+			"path": "ember-lazy-engine",
+			"name": "Fixture: Ember Lazy Engine"
 		}
 	],
-	"settings": {}
+	"settings": {
+		"terminal.integrated.cwd": "${workspaceFolder:Fixture: Ember App}"
+	}
 }

--- a/private-packages/fixtures-ember-v2/ember-app/package.json
+++ b/private-packages/fixtures-ember-v2/ember-app/package.json
@@ -13,14 +13,16 @@
   "scripts": {
     "build": "ember build",
     "start": "ember serve",
-    "pretest": "cd ../../../packages/@css-blocks/ember && yarn compile",
-    "test": "ember test"
+    "pretest": "cd ../../../packages/@css-blocks/ember && yarn compile && cd ../ember-app && yarn compile",
+    "test": "ember test",
+    "clean:debug": "rm -rf DEBUG"
   },
   "dependencies": {
     "@css-blocks-fixtures-v2/ember-addon": "^1.0.0",
     "@css-blocks-fixtures-v2/ember-engine": "^1.0.0",
     "@css-blocks-fixtures-v2/ember-lazy-engine": "^1.0.0",
     "@css-blocks/ember": "^0.1.0",
+    "@css-blocks/ember-app": "^0.1.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-engines": "^0.8.5"

--- a/private-packages/fixtures-ember-v2/ember-lazy-engine/package.json
+++ b/private-packages/fixtures-ember-v2/ember-lazy-engine/package.json
@@ -8,7 +8,6 @@
   ],
   "dependencies": {
     "@css-blocks/ember": "^0.1.0",
-    "@css-blocks/ember-app": "^0.1.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^5.2.0"
   },

--- a/private-packages/fixtures-ember-v2/ember-lazy-engine/package.json
+++ b/private-packages/fixtures-ember-v2/ember-lazy-engine/package.json
@@ -8,6 +8,7 @@
   ],
   "dependencies": {
     "@css-blocks/ember": "^0.1.0",
+    "@css-blocks/ember-app": "^0.1.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^5.2.0"
   },


### PR DESCRIPTION
Depends on: #457 

- Basic scaffolding and stubs for the ember-app addon, borrowed from the @css-blocks/ember addon.
- Add @css-blocks/ember-app as a dependency to ember v2 fixtures.
- Added names to ember-app VSCode workspace to disambiguate between the ember-app addon and the ember-app fixture.