### PR TITLE
Simplify Dynamic Attribute Rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 install:
   - lerna bootstrap --registry=https://registry.npmjs.org/
 
-script: lerna run test
+script: lerna run --concurrency 1 test
 
 cache:
   yarn: true

--- a/packages/@css-blocks/ember-app/package.json
+++ b/packages/@css-blocks/ember-app/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "test": "yarn run test:runner",
-    "test:runner": "echo TODO",
+    "test:runner": "mocha --opts test/mocha.opts dist/test",
     "compile": "tsc --build && tsc --build runtime",
     "prepare": "tsc --build --force && tsc --build --force runtime",
     "pretest": "yarn run compile",

--- a/packages/@css-blocks/ember-app/runtime/app/services/StyleEvaluator.ts
+++ b/packages/@css-blocks/ember-app/runtime/app/services/StyleEvaluator.ts
@@ -29,6 +29,141 @@ const enum FalsySwitchBehavior {
   default = 2,
 }
 
+/**
+ * Evaluates the runtime state of the style expression provided by the CSS
+ * Blocks rewriter.
+ *
+ * The result of evaluating a style expression is a set of global style ids
+ * that are currently enabled on this element by the author.
+ *
+ * Note: The full set of style ids that are enabled on the element is not known
+ * until after style resolution.
+ *
+ * The style expression is a list of values that consists of four sections:
+ * 1. Metadata
+ * 2. Block References
+ * 3. Style References
+ * 4. Conditionals
+ *
+ * ## Metadata
+ *
+ * The metadata consists of a single value, an integer that represents a schema
+ * version that describes the format of the style expression. If the rewrite
+ * changes, we'll use this to simultaneously support the old and new version(s).
+ *
+ * ## Block References
+ *
+ * The purpose of the block references is to enumerate the list of blocks that
+ * the styles come from. These blocks are later referred to in the style
+ * expression according to a number that represents a zero-based index into the
+ * order they appear in the block reference portion of the style expression.
+ *
+ * Format: `[blockCount: number, (sourceBlockGuid: string, runtimeBlockGuid: string | null)+]`
+ *
+ * - `blockCount` is the number of `sourceBlockGuid`/`runtimeBlockGuid` pairs that follow.
+ * - `sourceBlockGuid` is the guid of the block that was referenced in the source code.
+ * - `runtimeBlockGuid` is the guid of a block that implements the
+ *   `sourceBlockGuid` interface and is meant to replace the source block at
+ *   runtime. The `runtimeBlockGuid` is null when no runtime block is passed.
+ *   This means the source block is used.
+ *
+ * ## Style References
+ *
+ * The purpose of Style References is to enumerate the list of styles that
+ * are referenced from the style conditionals that follow. Later references
+ * to these styles use the zero-based index into the order they appear in this
+ * section.
+ *
+ * Format: `[styleCount: number, (blockIndex: number, styleName: string)+]
+ * styleCount: The number of styles
+ *
+ * - `styleCount` is the number of styles that follow. Each style is a pair
+ *   of values.
+ * - `blockIndex` is the index that references the block of the style.
+ * - `styleName` is a string that uniquely identifies the style in the block
+ *   given as well as in any block that implements the same interface.
+ *
+ * ## Style Conditionals
+ *
+ * Style conditionals are how the possible authored styles are selected based
+ * on the runtime state of the application. There are 4 types of conditionals.
+ *
+ * The general form of the conditionals section of the style expression is
+ *
+ * Format: `[conditionalCount <conditional>+]`
+ *
+ * Where each `<conditional>` has a first argument that indicates the type
+ * of the conditional and the remaining arguments for each conditional are
+ * specific to that conditional type.
+ *
+ * The behavior of the conditional is to enable one or more of the possible
+ * styles on the element. All styles start out as disabled and require a conditional
+ * in order to cause that style to become enabled. A conditional never disables
+ * a style. Although rare, several conditionals might enable the same style.
+ *
+ * ### Static Conditional
+ *
+ * The static conditional enables a single style. No javascript-based state is
+ * taken into account.
+ *
+ * Type Value: `Condition.static` or `1`
+ * Format: [type: number, styleIndex: number]
+ *
+ * - `styleIndex`: An index of one of the styles provided in the style
+ *   reference portion of the style expression.
+ *
+ * ### Toggle Conditional
+ *
+ * A toggle conditional is used to enable one or more styles based on the
+ * "truthiness" of a javascript value.
+ *
+ * Format: `[type: number, value: boolean, styleCount: number, (styleIndex: number)+]`
+ *
+ * - `type`: `Condition.toggle` or `2`
+ * - `value`: A javascript value will be coerced to a boolean.
+ * - `styleCount`: The number of styles that are enabled when this condition is true.
+ * - `styleIndex`: An index of one of the styles provided in the style
+ *   reference portion of the style expression.
+ *
+ * ### Ternary Conditional
+ *
+ * A ternary conditional is used to enable 0 or more styles when a variable is
+ * true or to enable a different set of 0 or more styles when the same variable
+ * is false.
+ *
+ * Format: `[type: number, value: boolean,
+ *           trueCount: number, (trueStyleIndex: number)*,
+ *           falseCount: number, (falseStyleIndex: number)*]`
+ *
+ * - `type`: `Condition.ternary` or `3`
+ * - `value`: A javascript value will be coerced to a boolean.
+ * - `trueCount`: The number of styles that are enabled when this condition is true.
+ * - `trueStyleIndex`: An index of one of the styles provided in the style
+ *   reference portion of the style expression.
+ * - `falseCount`: The number of styles that are enabled when this condition is false.
+ * - `falseStyleIndex`: An index of one of the styles provided in the style
+ *   reference portion of the style expression.
+ *
+ * ### Switch Conditional
+ *
+ * A switch conditional is used to enable one or more styles based on the value
+ * of a string matching one of several possible values. This conditional is
+ * different from the others in that it doesn't select styles from style
+ * reference section and it is the only conditional that can result in a
+ * runtime error.
+ *
+ * Format: `[type: number, blockIndex: number,
+ *           attributeName: string, value: string | null]`
+ *
+ * - `type`: `Condition.switch` or `4`
+ * - `blockIndex`: An index that references a block from the block reference
+ *   portion of the style expression.
+ * - `attributeName`: A string that uniquely identifies the attribute in the
+ *   block given as well as in any block that implements the same interface.
+ * - `value`: A string that must match one of the attribute's values. If null
+ *   is returned then no style is enabled (undefined is an error). If the value
+ *   does not match one of the known attribute values then an error is raised.
+ */
 export class StyleEvaluator {
   data: AggregateRewriteData;
   args: ClassNameExpression;

--- a/packages/@css-blocks/ember-app/runtime/app/services/StyleResolver.ts
+++ b/packages/@css-blocks/ember-app/runtime/app/services/StyleResolver.ts
@@ -29,10 +29,88 @@ function assertNever(_value: never): never {
 
 type Condition = StyleCondition | ImplicationCondition;
 
+/**
+ * The goal of style resolution is to use the relationships declared between
+ * different CSS Block styles to infer the presence of some styles based
+ * on the current runtime set of styles applied explicitly by the author.
+ *
+ * In addition to adding styles to an element, style resolution can result in
+ * the removal of an explicitly applied style when the element's styles do not
+ * meet the requirements of those styles based on the presence of related
+ * styles.
+ *
+ * Specifically, style resolution handles the following CSS Block features:
+ * - Block Inheritance.
+ * - Stylesheet-based style composition.
+ * - Block aliases.
+ * - Class attributes only matching an element when the element has the class.
+ *
+ * This class implements a graph where the nodes are styles and directed edges
+ * are "implications". That is, the edge of (s1, s2) means that style s1 implies
+ * the presence of style s2.
+ *
+ * The graph's start node is a javascript Symbol named `root`. A style is
+ * considered to be applied to the element if it is reachable from the start
+ * node.
+ *
+ * We first populate the graph the graph with all possible styles that might be
+ * applied to the element and as we do so we record any requirements for the presence
+ * of that applied style because we can't know whether the requirements are properly
+ * met until all styles are added to the graph.
+ *
+ * Some requirements only remove one or more implications, which might leave
+ * the style node connected through some other path. Other requirements can
+ * cause the style node and all outbound implications to be removed.
+ *
+ * Because we use a unique number to represent a style, this graph is
+ * constructed a little differently from most graphs: There is no node type.
+ * Instead, we use a Map where the key is a style id and the value is a set of
+ * style ids implied by the key.
+ *
+ * The RuntimeDataGenerator emits data about the CSS Blocks styles that has
+ * undergone a significant amount of data preparation in order for this resolver
+ * to run without needing to perform its work in the domain of the CSS Block
+ * interfaces. Instead the CSS Block relationships are boiled down to implied
+ * styles and style requirements.
+ *
+ * An implied style takes one of three forms:
+ * - A style id (always implied)
+ * - A css class name (from an alias)
+ * - A conditional style implies one or more styles but only when the condition
+ * is satisfied. The condition is a boolean style expression of the same format
+ * that is used by the optimizer's output classnames. These conditions become a
+ * type of style requirement.
+ *
+ * A style requirement is a mapping from a style id to a boolean style
+ * expression that must evaluate to true in order for the style to be allowed
+ * to remain on the element.
+ *
+ * In order to enforce style requirements, once we've added all possible styles
+ * to the graph, we iterate over the requirements and remove any styles or
+ * implications that are not satisfied. If any styles are removed, this may
+ * cause a style requirement that previously was satisfied to become
+ * dissatisfied. Because of this we keep iterating over the list of style
+ * requirements until no styles are removed.
+ *
+ * During style requirements processing it's possible for sections of the graph
+ * to become disconnected from the root node, thus causing all the styles that
+ * were transitively implied by the removed style to also be removed from the
+ * element.
+ *
+ * Unfortunately, this means that during requirements processing we must
+ * perform a depth first search for any style that is mentioned in a boolean
+ * style expression. Fortunately, the size of the graph is generally small
+ * and relatively flat. However, there are ways to optimize the graph
+ * so that these reads are faster and in aggregate might result in a small
+ * runtime performance boost.
+ */
 export class StyleResolver {
+  /** source data for implied styles and style requirements. */
   data: AggregateRewriteData;
+  /** This is the implication graph. */
   implications: Map<number | typeof root, Set<number>>;
   _impliedClassNames: Map<number, Set<string>>;
+  /** Style requirements that must be satisfied. */
   conditionals: Array<Condition>;
   constructor(data: AggregateRewriteData) {
     this.data = data;
@@ -42,7 +120,7 @@ export class StyleResolver {
   }
 
   /**
-   * Returns true if the style is connected to the root node.
+   * Returns true if the style is currently connected to the root node.
    */
   public hasStyle(styleToFind: number): boolean {
     return this.hasStyleFrom(root, styleToFind);
@@ -59,16 +137,26 @@ export class StyleResolver {
     return false;
   }
 
+  /**
+   * Adds an explicitly declared style to the style resolver.
+   */
   public addStyle(style: number) {
     this.addImpliedStyle(root, style);
   }
 
+  /**
+   * This method mutates the graph and should only be called a single time
+   * once all styles are added.
+   */
   public resolve(): Set<number> {
     this.importRequirements();
     this.processConditions();
     return this.currentStyles();
   }
 
+  /**
+   * Gets all the implied class names for styles currently connected to root.
+   */
   public impliedClassNames(): Set<string> {
     let classNames = new Set<string>();
     for (let style of this.currentStyles()) {
@@ -93,6 +181,10 @@ export class StyleResolver {
     this._importImpliedStyles(style);
   }
 
+  /**
+   * Imports implied styles from the read only aggregate rewrite data into this
+   * resolver.
+   */
   private _importImpliedStyles(fromStyle: number) {
     let implied = this.data.impliedStyles[fromStyle];
     if (implied) {
@@ -108,6 +200,9 @@ export class StyleResolver {
     }
   }
 
+  /**
+   * Adds style implications and records the associated style requirements.
+   */
   private addCondition(fromStyle: number, condition: ConditionalStyle) {
     this.conditionals.push({
       type: IMPLICATION_TYPE,
@@ -149,6 +244,9 @@ export class StyleResolver {
     }
   }
 
+  /**
+   * Evaluates a boolean style expression.
+   */
   private evaluateExpression(expr: StyleExpression): boolean {
     if (typeof expr === "number") return this.hasStyle(expr);
     let op: Operator = expr[0];
@@ -193,6 +291,10 @@ export class StyleResolver {
     return wasRemoved;
   }
 
+  /**
+   * Helper function that is used to construct a set of all styles reachable
+   * from the root.
+   */
   private currentStylesFrom(fromStyle: number | typeof root, styles: Set<number>): void {
     if (fromStyle !== root) {
       styles.add(fromStyle);

--- a/packages/@css-blocks/ember-app/runtime/app/services/css-blocks.ts
+++ b/packages/@css-blocks/ember-app/runtime/app/services/css-blocks.ts
@@ -74,6 +74,10 @@ export default class CSSBlocksService extends Service {
     return result;
   }
 
+  /**
+   * Returns the list of optimization outputs that mention
+   * any style applied to the element.
+   */
   getPossibleOptimizations(stylesApplied: Set<number>): Array<OptimizationEntry> {
     let optimizations: Array<number> = [];
     for (let style of stylesApplied) {

--- a/packages/@css-blocks/ember-app/src/AggregateRewriteData.ts
+++ b/packages/@css-blocks/ember-app/src/AggregateRewriteData.ts
@@ -77,6 +77,19 @@ export interface AggregateRewriteData {
 }
 
 export interface BlockInfo {
+  // Maps the source name of the attribute (E.g. `.button[color]`) to a
+  // a map that maps the value of the attribute to the source name of that
+  // attribute value. Example:
+  // {
+  //   ":scope[mode]": {
+  //      "collapsed": ":scope[mode=collapsed]",
+  //      "open": ":scope[mode=open]",
+  //      "minimal": ":scope[mode=minimal]",
+  //   }
+  // }
+  // The value returned from this mapping is suitable for being passed as a key
+  // to `blockInterfaceStyles`.
+  groups: ObjectDictionary<ObjectDictionary<string>>;
   // The styles of this block
   // Note: this includes all the styles that are inherited but not overridden
   //       but does not include the styles that are inherited but then overridden.

--- a/packages/@css-blocks/ember-app/test/runtime-data-generator-test.ts
+++ b/packages/@css-blocks/ember-app/test/runtime-data-generator-test.ts
@@ -1,0 +1,59 @@
+import { Block, BlockFactory } from "@css-blocks/core";
+import { EmberAnalyzer } from "@css-blocks/ember-utils";
+import { StyleMapping } from "@opticss/template-api";
+import * as assert from "assert";
+
+import { RuntimeDataGenerator } from "../src/RuntimeDataGenerator";
+
+describe("Runtime Data Generator", function () {
+
+  beforeEach(async () => {
+  });
+
+  afterEach(async () => {
+  });
+
+  it("Generates block information", function () {
+    let factory = new BlockFactory({});
+    let analyzer = new EmberAnalyzer(factory);
+    let mapping = new StyleMapping({analyzedAttributes: ["class"], analyzedTagnames: false, rewriteIdents: {id: false, class: true}});
+    let block = new Block("test-block-1", "test-block-1", "abcde");
+    let aClass = block.ensureClass("a-class");
+    let attr = aClass.ensureAttribute("[an-attr]");
+    attr.ensureValue("one");
+    attr.ensureValue("two");
+    attr.ensureValue("three");
+    let subBlock = new Block("test-block-2", "test-block-2", "abcde");
+    subBlock.setBase(block);
+    let subClass = subBlock.ensureClass("a-class");
+    let subAttr = subClass.ensureAttribute("[an-attr]");
+    subAttr.ensureValue("three");
+    subAttr.ensureValue("four");
+    let generator = new RuntimeDataGenerator([block, subBlock], mapping, analyzer, factory.configuration, new Set());
+    let blockInfo = generator.generateBlockInfo(block);
+    assert.deepEqual(
+      blockInfo,
+      {
+        blockInterfaceStyles: {
+          ".a-class": 0,
+          ".a-class[an-attr=one]": 1,
+          ".a-class[an-attr=three]": 2,
+          ".a-class[an-attr=two]": 3,
+          ":scope": 4,
+        },
+        groups: {
+          ".a-class[an-attr]": {
+            one: ".a-class[an-attr=one]",
+            two: ".a-class[an-attr=two]",
+            three: ".a-class[an-attr=three]",
+          },
+        },
+        implementations: {
+          "0": [ 0, 1, 2, 3, 4 ],
+          "1": [ 5, 1, 6, 3, 7 ],
+        },
+      },
+    );
+  });
+
+});

--- a/packages/@css-blocks/ember/test/template-rewrite-test.ts
+++ b/packages/@css-blocks/ember/test/template-rewrite-test.ts
@@ -188,7 +188,7 @@ describe("Template Rewriting", function() {
       minify(`
         <div class={{-css-blocks 0 1 "${defaultBlock.guid}" null 1 0 ":scope" 1 1 0}}>
           <h1 class={{-css-blocks 0 1 "${headerBlock.guid}" null 1 0 ":scope" 1 1 0}}>Hello,
-          <span class={{-css-blocks 0 3 "${defaultBlock.guid}" null "${headerBlock.guid}" null "${typographyBlock.guid}" null 6 0 ".world" 1 ".emphasis" 2 ".underline" 0 ".world[thick]" 1 ".emphasis[style=bold]" 1 ".emphasis[style=italic]" 5 1 1 1 2 3 isWorld 1 0 0 2 (eq isThick 1) 1 3 4 1 textStyle 2 "bold" 1 4 "italic" 1 5}}>World</span>!</h1>
+          <span class={{-css-blocks 0 3 "${headerBlock.guid}" null "${typographyBlock.guid}" null "${defaultBlock.guid}" null 4 0 ".emphasis" 1 ".underline" 2 ".world" 2 ".world[thick]" 5 1 0 1 1 3 isWorld 1 2 0 2 (eq isThick 1) 1 3 4 1 0 ".emphasis[style]" textStyle}}>World</span>!</h1>
           <div class={{-css-blocks 0 1 "${defaultBlock.guid}" null 2 0 ".world" 0 ".planet" 1 3 isWorld 1 0 1 1}}>World</div>
           <div class={{-css-blocks 0 1 "${defaultBlock.guid}" null 2 0 ".planet" 0 ".world" 1 3 isWorld 1 0 1 1}}>World</div>
           <div class={{-css-blocks 0 1 "${defaultBlock.guid}" null 1 0 ".world" 1 3 isWorld 0 1 0}}>World</div>
@@ -334,7 +334,7 @@ describe("Template Rewriting", function() {
       minify(`
         <div class={{-css-blocks 0 1 "${defaultBlock.guid}" null 1 0 ":scope" 1 1 0}}>
           <h1 class={{-css-blocks 0 1 "${headerBlock.guid}" null 1 0 ":scope" 1 1 0}}>Hello,
-          <World cssClass={{-css-blocks 0 2 "${defaultBlock.guid}" null "${headerBlock.guid}" null 5 0 ".world" 1 ".emphasis" 0 ".world[thick]" 1 ".emphasis[style=bold]" 1 ".emphasis[style=italic]" 4 1 0 1 1 1 2 4 1 (textStyle) 2 "bold" 1 3 "italic" 1 4}} />!</h1>
+          <World cssClass={{-css-blocks 0 2 "${headerBlock.guid}" null "${defaultBlock.guid}" null 3 1 ".world" 0 ".emphasis" 1 ".world[thick]" 4 1 0 1 1 1 2 4 1 0 ".emphasis[style]" (textStyle)}} />!</h1>
         </div>
       `));
     let analysis = result.analysis.serialize();
@@ -400,7 +400,7 @@ describe("Template Rewriting", function() {
         <h1 class={{-css-blocks 0 1 "${headerBlock.guid}" null 1 0 ":scope" 1 1 0}}>Hello,
           {{yield (hash
             classnames=(hash
-              action=(-css-blocks 0 2 "${defaultBlock.guid}" null "${headerBlock.guid}" null 5 0 ".world" 1 ".emphasis" 0 ".world[thick]" 1 ".emphasis[style=bold]" 1 ".emphasis[style=italic]" 4 1 0 1 1 2 isThick 1 2 4 1 (textStyle) 2 "bold" 1 3 "italic" 1 4)))}}
+              action=(-css-blocks 0 2 "${headerBlock.guid}" null "${defaultBlock.guid}" null 3 1 ".world" 0 ".emphasis" 1 ".world[thick]" 4 1 0 1 1 2 isThick 1 2 4 1 0 ".emphasis[style]" (textStyle))))}}
         </h1>
       </div>
       `));


### PR DESCRIPTION
This change greatly simplifies the per-element rewrite for elements that have dynamic attribute values. In the element rewrite we no longer enumerate all the attribute values as possible styles and we don't enumerate the specific values as part of the switch condition. Instead we just reference the attribute as being a switch condition and let the runtime fill in the possible values from new information that is passed in for the aggregate rewrite data.

The aggregate rewrite data is more explicit than it strictly needs to be, the rewrite code could do some sort of string manipulation in order to construct the attribute value style name instead of looking it up in a table. However that solution would preclude a later optimization where we optimize away the strings and replace them with unique numbers.

In production code this change reduces the rewrite significantly (by more than 30 arguments in one element I examined) and should produce a significant savings in aggregate by avoiding duplication when the same attributes are used dynamically on different template elements throughout the application.

TODO:
- [x] Code-level documentation on the rewrite argument format and runtime processing code.