### PR TITLE
Set eyeglass root within a directory-scoped processor.

### DIFF
--- a/packages/@css-blocks/eyeglass/package.json
+++ b/packages/@css-blocks/eyeglass/package.json
@@ -50,11 +50,15 @@
     "yarn": "1.22.0"
   },
   "devDependencies": {
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/node-sass": "^4.11.0",
     "@types/sinon": "^7.5.1",
     "eyeglass": "^2.4.2",
     "mocha": "^7.0.1",
     "node-sass": "^4.13.1",
     "sinon": "^8.0.4"
+  },
+  "dependencies": {
+    "lodash.clonedeep": "^4.5.0"
   }
 }

--- a/packages/@css-blocks/eyeglass/src/index.ts
+++ b/packages/@css-blocks/eyeglass/src/index.ts
@@ -1,9 +1,9 @@
 import type { OptionalPreprocessor, OptionalPreprocessorSync, Preprocessor, PreprocessorSync, ProcessedFile, ResolvedConfiguration } from "@css-blocks/core";
 import type { EyeglassOptions, default as Eyeglass } from "eyeglass"; // works, even tho a cjs export. huh.
+import cloneDeep = require("lodash.clonedeep");
 import type { Result, SassError } from "node-sass";
 import type SassImplementation from "node-sass";
 import { sep as PATH_SEPARATOR } from "path";
-import cloneDeep = require("lodash.clonedeep");
 
 export type Adaptor = (sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: EyeglassOptions) => Preprocessor;
 export type AdaptorSync = (sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: EyeglassOptions) => PreprocessorSync;
@@ -123,6 +123,8 @@ export class DirectoryScopedPreprocessor implements PreprocessorProvider {
      * eyeglass.VERSION.
      */
     init(sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: EyeglassOptions = {}) {
+        options = cloneDeep(options);
+        setEyeglassRoot(options, this.filePrefix);
         let sassOptions = this.setupOptions(options);
 
         let sassOptionsSync = cloneDeep(sassOptions);
@@ -199,6 +201,14 @@ export class DirectoryScopedPreprocessor implements PreprocessorProvider {
             }
         };
     }
+}
+
+function setEyeglassRoot(options: EyeglassOptions, root: string): EyeglassOptions {
+    if (!options.eyeglass) {
+        options.eyeglass = {};
+    }
+    options.eyeglass.root = root;
+    return options;
 }
 
 /**

--- a/packages/@css-blocks/eyeglass/src/index.ts
+++ b/packages/@css-blocks/eyeglass/src/index.ts
@@ -3,6 +3,7 @@ import type { EyeglassOptions, default as Eyeglass } from "eyeglass"; // works, 
 import type { Result, SassError } from "node-sass";
 import type SassImplementation from "node-sass";
 import { sep as PATH_SEPARATOR } from "path";
+import cloneDeep = require("lodash.clonedeep");
 
 export type Adaptor = (sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: EyeglassOptions) => Preprocessor;
 export type AdaptorSync = (sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: EyeglassOptions) => PreprocessorSync;
@@ -123,7 +124,10 @@ export class DirectoryScopedPreprocessor implements PreprocessorProvider {
      */
     init(sass: typeof SassImplementation, eyeglass: typeof Eyeglass, options: EyeglassOptions = {}) {
         let sassOptions = this.setupOptions(options);
-        let sassOptionsSync = this.setupOptionsSync ? this.setupOptionsSync(sassOptions) : sassOptions;
+
+        let sassOptionsSync = cloneDeep(sassOptions);
+        sassOptionsSync = this.setupOptionsSync ? this.setupOptionsSync(sassOptionsSync) : sassOptionsSync;
+
         this.scssProcessor = adaptor(sass, eyeglass, sassOptions);
         this.scssProcessorSync = adaptorSync(sass, eyeglass, sassOptionsSync);
     }
@@ -146,7 +150,7 @@ export class DirectoryScopedPreprocessor implements PreprocessorProvider {
      * provided from the application that will be used for compiling this
      * package's block files synchronously.
      *
-     * The options passed into this function are those returned by
+     * The options passed into this function are a copy of those returned by
      * setupOptions(), so this method only needs to update those options as
      * appropriate to support synchronous compilation.
      *

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,6 +3013,13 @@
     "@types/node" "*"
     "@types/webpack" "*"
 
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
+  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.merge@^4.6.6":
   version "4.6.6"
   resolved "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"


### PR DESCRIPTION
In a directory scoped processor, we want to treat the root directory of the processor as the eyeglass root. We override any root setting that the application's configuration has provided, but we allow the root to be overridden in the processor's `setupOptions()` method.
    
Usually the application's root is good enough for compilation, but there are situations where the directory structures don't align and it's important for the scoped processor to have its root take precedence. Namely: `yarn link`'ed development requires this.