### PR TITLE
Simplify block lookups for a template

### DIFF
--- a/packages/@css-blocks/ember-app/src/broccoli-plugin.ts
+++ b/packages/@css-blocks/ember-app/src/broccoli-plugin.ts
@@ -11,10 +11,10 @@ import * as FSTree from "fs-tree-diff";
 import { OptiCSSOptions, Optimizer, parseSelector, postcss } from "opticss";
 import * as path from "path";
 
+import { AggregateRewriteData } from "./AggregateRewriteData";
 import { RuntimeDataGenerator } from "./RuntimeDataGenerator";
 import { cssBlocksPostprocessFilename, cssBlocksPreprocessFilename, optimizedStylesPostprocessFilepath, optimizedStylesPreprocessFilepath } from "./utils/filepaths";
 import { AddonEnvironment } from "./utils/interfaces";
-import { AggregateRewriteData } from "./AggregateRewriteData";
 
 const debug = debugGenerator("css-blocks:ember-app");
 

--- a/packages/@css-blocks/ember-utils/src/EmberAnalysis.ts
+++ b/packages/@css-blocks/ember-utils/src/EmberAnalysis.ts
@@ -3,7 +3,7 @@ import { AnalysisImpl, Block, DEFAULT_EXPORT, TemplateValidatorOptions } from "@
 import { HandlebarsTemplate, TEMPLATE_TYPE as HANDLEBARS_TEMPLATE } from "./HandlebarsTemplate";
 
 export class EmberAnalysis extends AnalysisImpl<HANDLEBARS_TEMPLATE> {
-  constructor(template: HandlebarsTemplate, block: Block | undefined, options: TemplateValidatorOptions) {
+  constructor(template: HandlebarsTemplate, block: Block | undefined | null, options: TemplateValidatorOptions) {
     super(template, options);
     if (block) {
       this.addBlock(DEFAULT_EXPORT, block);


### PR DESCRIPTION
Now that we have synchronous block loading we don't have to go parse all the blocks just in case we might need them during template compilation.[

This also fixes a runtime error that I occured in the situation where an application doesn't have any block files.