### PR TITLE
Add the possibility to set options.parserOpts.outputMode

### DIFF
--- a/packages/@css-blocks/ember-cli/index.js
+++ b/packages/@css-blocks/ember-cli/index.js
@@ -324,7 +324,7 @@ module.exports = {
     if (!options.parserOpts.rootDir) {
       options.parserOpts.rootDir = rootDir;
     }
-    options.parserOpts.outputMode = "BEM_UNIQUE";
+    options.parserOpts.outputMode = options.parserOpts.outputMode ||"BEM_UNIQUE";
 
 
     if (options.output !== undefined && typeof options.output !== "string") {


### PR DESCRIPTION
Currently the outputMode is hard coded inside the ember-cli addon. I changed this to add the possibility to change the outputMode inside the ember-cli-build.js.